### PR TITLE
Exclude SCM, IDE, and build output files from RAT checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,13 @@
                 <excludes>
                   <exclude>build-number.txt</exclude>
                   <exclude>README.md</exclude>
+                  <exclude>**/target/**</exclude>
+                  <exclude>**/.git/**</exclude>
+                  <exclude>**/.idea/**</exclude>
+                  <exclude>**/*.iml</exclude>
+                  <exclude>**/.project</exclude>
+                  <exclude>**/.classpath</exclude>
+                  <exclude>**/.settings/**</exclude>
                 </excludes>
               </configuration>
             </execution>


### PR DESCRIPTION
Exclude SCM, IDE, and build output files from RAT checks.
