### PR TITLE
Do lazy initialization of PooledClientProvider to avoid guide injection error.

### DIFF
--- a/tephra-core/src/main/java/com/continuuity/tephra/distributed/TransactionServiceClient.java
+++ b/tephra-core/src/main/java/com/continuuity/tephra/distributed/TransactionServiceClient.java
@@ -151,13 +151,6 @@ public class TransactionServiceClient implements TransactionSystemClient {
     LOG.debug("Retry strategy is " + this.retryStrategyProvider);
 
     this.clientProvider = clientProvider;
-    try {
-      this.clientProvider.initialize();
-      LOG.debug("Tx client provider is " + this.clientProvider);
-    } catch (Exception e) {
-      LOG.error("Failed to initialize Tx client provider", e);
-      throw Throwables.propagate(e);
-    }
   }
 
   /**


### PR DESCRIPTION
- Guice injection error could raised if the TransactionServiceClient instance is being injected to another object.
  - During the instantiation of TransactionServiceClient, which in turn call PooledClientProvider.initialize(). The initialization would fails if it is not yet connected to ZooKeeper, which would be the case when still constructing the Guice Injector, depending on whether the DiscoveryServiceClient do auto-connect to zookeeper or not, which is not guaranteed.
- It's also better not to do resource related initialization in Guice constructor, as suggested in Guice guideline.
