### PR TITLE
TEPHRA-3 Switch tx write pointer to increment prior to assignment

### DIFF
--- a/tephra-core/src/test/java/com/continuuity/tephra/TransactionSystemTest.java
+++ b/tephra-core/src/test/java/com/continuuity/tephra/TransactionSystemTest.java
@@ -221,6 +221,7 @@ public abstract class TransactionSystemTest {
     client.commit(tx1);
     client.canCommit(tx2, asList(C3, C4));
 
+    Transaction txPreReset = client.startShort();
     long currentTs = System.currentTimeMillis();
     client.resetState();
 
@@ -230,6 +231,11 @@ public abstract class TransactionSystemTest {
     Assert.assertEquals(0, snapshot.getInProgress().size());
     Assert.assertEquals(0, snapshot.getCommittingChangeSets().size());
     Assert.assertEquals(0, snapshot.getCommittedChangeSets().size());
+
+    // confirm that transaction IDs are not reset
+    Transaction txPostReset = client.startShort();
+    Assert.assertTrue("New tx ID should be greater than last ID before reset",
+                      txPostReset.getWritePointer() > txPreReset.getWritePointer());
   }
 
   private Collection<byte[]> asList(byte[]... val) {

--- a/tephra-core/src/test/java/com/continuuity/tephra/persist/AbstractTransactionStateStorageTest.java
+++ b/tephra-core/src/test/java/com/continuuity/tephra/persist/AbstractTransactionStateStorageTest.java
@@ -284,7 +284,7 @@ public abstract class AbstractTransactionStateStorageTest {
       Map<Long, Set<ChangeId>> committed = Maps.newHashMap();
       TransactionSnapshot snapshot = new TransactionSnapshot(now, 0, writePointer++, invalid,
                                                              inprogress, committing, committed);
-      TransactionEdit dummyEdit = TransactionEdit.createStarted(1, 0, Long.MAX_VALUE, 2);
+      TransactionEdit dummyEdit = TransactionEdit.createStarted(1, 0, Long.MAX_VALUE);
 
       // write snapshot 1
       storage.writeSnapshot(snapshot);
@@ -437,7 +437,7 @@ public abstract class AbstractTransactionStateStorageTest {
         case INPROGRESS:
           edits.add(
             TransactionEdit.createStarted(writePointer, writePointer - 1,
-                                          System.currentTimeMillis() + 300000L, writePointer + 1));
+                                          System.currentTimeMillis() + 300000L));
           break;
         case COMMITTING:
           edits.add(TransactionEdit.createCommitting(writePointer, generateChangeSet(10)));

--- a/tephra-core/src/test/java/com/continuuity/tephra/persist/TransactionEditTest.java
+++ b/tephra-core/src/test/java/com/continuuity/tephra/persist/TransactionEditTest.java
@@ -35,7 +35,7 @@ public class TransactionEditTest {
   public void testV1SerdeCompat() throws Exception {
     // start tx edit and committed tx edit cover all fields of tx edit
     // NOTE: set visibilityUpperBound to 0 as this is expected default for decoding older version that doesn't store it
-    verifyDecodingSupportsV1(TransactionEdit.createStarted(2L, 0L, 1000L, 3L));
+    verifyDecodingSupportsV1(TransactionEdit.createStarted(2L, 0L, 1000L));
     verifyDecodingSupportsV1(TransactionEdit.createCommitted(2L,
                                                                       Sets.newHashSet(new ChangeId(Bytes.toBytes("c"))),
                                                                       3L, true));


### PR DESCRIPTION
Switches transaction write pointer generation to happen at the start of a request.  This ensures that generated transaction write pointers reflect the current timestamp, fixes issues with resetting the transaction state, and cleans up some unnecessary tracking of the next write pointer.
