### PR TITLE
TEPHRA-4 TransactionVisibilityFilter should support additional filtering on visible cells

### DIFF
--- a/tephra-hbase-compat-0.94/src/main/java/com/continuuity/tephra/coprocessor/hbase94/TransactionVisibilityFilter.java
+++ b/tephra-hbase-compat-0.94/src/main/java/com/continuuity/tephra/coprocessor/hbase94/TransactionVisibilityFilter.java
@@ -20,6 +20,7 @@ import com.continuuity.tephra.Transaction;
 import com.continuuity.tephra.TxConstants;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterBase;
 import org.apache.hadoop.hbase.util.Bytes;
 
@@ -27,6 +28,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Applies filtering of data based on transactional visibility (HBase 0.94 specific version).
@@ -39,12 +41,38 @@ public class TransactionVisibilityFilter extends FilterBase {
   private final Map<byte[], Long> oldestTsByFamily;
   // if false, empty values will be interpreted as deletes
   private final boolean allowEmptyValues;
+  // optional sub-filter to apply to visible cells
+  private final Filter cellFilter;
 
   // since we traverse KVs in order, cache the current oldest TS to avoid map lookups per KV
   private byte[] currentFamily = new byte[0];
   private long currentOldestTs;
 
+  /**
+   * Creates a new {@link org.apache.hadoop.hbase.filter.Filter} for returning data only from visible transactions.
+   *
+   * @param tx The current transaction to apply.  Only data visible to this transaction will be returned.
+   * @param ttlByFamily Map of time-to-live (TTL) (in milliseconds) by column family name.
+   * @param allowEmptyValues If {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
+   *                         these will be interpreted as "delete" markers and the column will be filtered out.
+   */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues) {
+    this(tx, ttlByFamily, allowEmptyValues, null);
+  }
+
+  /**
+   * Creates a new {@link org.apache.hadoop.hbase.filter.Filter} for returning data only from visible transactions.
+   *
+   * @param tx The current transaction to apply.  Only data visible to this transaction will be returned.
+   * @param ttlByFamily Map of time-to-live (TTL) (in milliseconds) by column family name.
+   * @param allowEmptyValues If {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
+   *                         these will be interpreted as "delete" markers and the column will be filtered out.
+   * @param cellFilter If non-null, this filter will be applied to all cells visible to the current transaction, by
+   *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.KeyValue)}.  If null, then
+   *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
+   */
+  public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
+                                     @Nullable Filter cellFilter) {
     this.tx = tx;
     this.oldestTsByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
     for (Map.Entry<byte[], Long> ttlEntry : ttlByFamily.entrySet()) {
@@ -53,6 +81,7 @@ public class TransactionVisibilityFilter extends FilterBase {
                            familyTTL <= 0 ? 0 : tx.getVisibilityUpperBound() - familyTTL * TxConstants.MAX_TX_PER_MS);
     }
     this.allowEmptyValues = allowEmptyValues;
+    this.cellFilter = cellFilter;
   }
 
   @Override
@@ -74,8 +103,13 @@ public class TransactionVisibilityFilter extends FilterBase {
         // skip "deleted" cell
         return ReturnCode.NEXT_COL;
       }
-      // as soon as we find a KV to include we can move to the next column
-      return ReturnCode.INCLUDE_AND_NEXT_COL;
+      // cell is visible
+      if (cellFilter != null) {
+        return cellFilter.filterKeyValue(kv);
+      } else {
+        // as soon as we find a KV to include we can move to the next column
+        return ReturnCode.INCLUDE_AND_NEXT_COL;
+      }
     } else {
       return ReturnCode.SKIP;
     }

--- a/tephra-hbase-compat-0.94/src/main/java/com/continuuity/tephra/hbase/Filters.java
+++ b/tephra-hbase-compat-0.94/src/main/java/com/continuuity/tephra/hbase/Filters.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2014 Continuuity, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.continuuity.tephra.hbase;
+
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+
+/**
+ * Utility methods for working with HBase filters.
+ */
+public final class Filters {
+  /**
+   * Adds {@code overrideFilter} on to {@code baseFilter}, if it exists, otherwise replaces it.
+   */
+  public static Filter combine(Filter overrideFilter, Filter baseFilter) {
+    if (baseFilter != null) {
+      FilterList filterList = new FilterList(FilterList.Operator.MUST_PASS_ALL);
+      filterList.addFilter(baseFilter);
+      filterList.addFilter(overrideFilter);
+      return filterList;
+    }
+    return overrideFilter;
+  }
+}

--- a/tephra-hbase-compat-0.96/src/main/java/com/continuuity/tephra/coprocessor/hbase96/TransactionDataJanitor.java
+++ b/tephra-hbase-compat-0.96/src/main/java/com/continuuity/tephra/coprocessor/hbase96/TransactionDataJanitor.java
@@ -21,6 +21,7 @@ import com.continuuity.tephra.TransactionCodec;
 import com.continuuity.tephra.TxConstants;
 import com.continuuity.tephra.coprocessor.TransactionStateCache;
 import com.continuuity.tephra.coprocessor.TransactionStateCacheSupplier;
+import com.continuuity.tephra.hbase.Filters;
 import com.continuuity.tephra.persist.TransactionSnapshot;
 import com.continuuity.tephra.util.TxUtils;
 import com.google.common.base.Supplier;
@@ -88,8 +89,8 @@ public class TransactionDataJanitor extends BaseRegionObserver {
 
   private TransactionStateCache cache;
   private final TransactionCodec txCodec;
-  private Map<byte[], Long> ttlByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-  private boolean allowEmptyValues = TxConstants.ALLOW_EMPTY_VALUES_DEFAULT;
+  protected Map<byte[], Long> ttlByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+  protected boolean allowEmptyValues = TxConstants.ALLOW_EMPTY_VALUES_DEFAULT;
 
   public TransactionDataJanitor() {
     this.txCodec = new TransactionCodec();
@@ -141,8 +142,7 @@ public class TransactionDataJanitor extends BaseRegionObserver {
     if (tx != null) {
       get.setMaxVersions(tx.excludesSize() + 1);
       get.setTimeRange(TxUtils.getOldestVisibleTimestamp(ttlByFamily, tx), TxUtils.getMaxVisibleTimestamp(tx));
-      Filter newFilter = combineFilters(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues),
-                                        get.getFilter());
+      Filter newFilter = Filters.combine(getTransactionFilter(tx), get.getFilter());
       get.setFilter(newFilter);
     }
   }
@@ -154,8 +154,7 @@ public class TransactionDataJanitor extends BaseRegionObserver {
     if (tx != null) {
       scan.setMaxVersions(tx.excludesSize() + 1);
       scan.setTimeRange(TxUtils.getOldestVisibleTimestamp(ttlByFamily, tx), TxUtils.getMaxVisibleTimestamp(tx));
-      Filter newFilter = combineFilters(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues),
-                                        scan.getFilter());
+      Filter newFilter = Filters.combine(getTransactionFilter(tx), scan.getFilter());
       scan.setFilter(newFilter);
     }
     return s;
@@ -203,14 +202,13 @@ public class TransactionDataJanitor extends BaseRegionObserver {
     return scanner;
   }
 
-  private Filter combineFilters(Filter overrideFilter, Filter baseFilter) {
-    if (baseFilter != null) {
-      FilterList filterList = new FilterList(FilterList.Operator.MUST_PASS_ALL);
-      filterList.addFilter(baseFilter);
-      filterList.addFilter(overrideFilter);
-      return filterList;
-    }
-    return overrideFilter;
+  /**
+   * Derived classes can override this method to customize the filter used to return data visible for the current
+   * transaction.
+   * @param tx The current transaction to apply.
+   */
+  protected Filter getTransactionFilter(Transaction tx) {
+    return new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues);
   }
 
   private DataJanitorRegionScanner createDataJanitorRegionScanner(ObserverContext<RegionCoprocessorEnvironment> e,

--- a/tephra-hbase-compat-0.96/src/main/java/com/continuuity/tephra/hbase/Filters.java
+++ b/tephra-hbase-compat-0.96/src/main/java/com/continuuity/tephra/hbase/Filters.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2014 Continuuity, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.continuuity.tephra.hbase;
+
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+
+/**
+ * Utility methods for working with HBase filters.
+ */
+public final class Filters {
+  /**
+   * Adds {@code overrideFilter} on to {@code baseFilter}, if it exists, otherwise replaces it.
+   */
+  public static Filter combine(Filter overrideFilter, Filter baseFilter) {
+    if (baseFilter != null) {
+      FilterList filterList = new FilterList(FilterList.Operator.MUST_PASS_ALL);
+      filterList.addFilter(baseFilter);
+      filterList.addFilter(overrideFilter);
+      return filterList;
+    }
+    return overrideFilter;
+  }
+}

--- a/tephra-hbase-compat-0.98/src/main/java/com/continuuity/tephra/coprocessor/hbase98/TransactionDataJanitor.java
+++ b/tephra-hbase-compat-0.98/src/main/java/com/continuuity/tephra/coprocessor/hbase98/TransactionDataJanitor.java
@@ -21,6 +21,7 @@ import com.continuuity.tephra.TransactionCodec;
 import com.continuuity.tephra.TxConstants;
 import com.continuuity.tephra.coprocessor.TransactionStateCache;
 import com.continuuity.tephra.coprocessor.TransactionStateCacheSupplier;
+import com.continuuity.tephra.hbase.Filters;
 import com.continuuity.tephra.persist.TransactionSnapshot;
 import com.continuuity.tephra.util.TxUtils;
 import com.google.common.base.Supplier;
@@ -88,8 +89,8 @@ public class TransactionDataJanitor extends BaseRegionObserver {
 
   private TransactionStateCache cache;
   private final TransactionCodec txCodec;
-  private Map<byte[], Long> ttlByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-  private boolean allowEmptyValues = TxConstants.ALLOW_EMPTY_VALUES_DEFAULT;
+  protected Map<byte[], Long> ttlByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+  protected boolean allowEmptyValues = TxConstants.ALLOW_EMPTY_VALUES_DEFAULT;
 
   public TransactionDataJanitor() {
     this.txCodec = new TransactionCodec();
@@ -141,8 +142,7 @@ public class TransactionDataJanitor extends BaseRegionObserver {
     if (tx != null) {
       get.setMaxVersions(tx.excludesSize() + 1);
       get.setTimeRange(TxUtils.getOldestVisibleTimestamp(ttlByFamily, tx), TxUtils.getMaxVisibleTimestamp(tx));
-      Filter newFilter = combineFilters(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues),
-                                        get.getFilter());
+      Filter newFilter = Filters.combine(getTransactionFilter(tx), get.getFilter());
       get.setFilter(newFilter);
     }
   }
@@ -154,8 +154,7 @@ public class TransactionDataJanitor extends BaseRegionObserver {
     if (tx != null) {
       scan.setMaxVersions(tx.excludesSize() + 1);
       scan.setTimeRange(TxUtils.getOldestVisibleTimestamp(ttlByFamily, tx), TxUtils.getMaxVisibleTimestamp(tx));
-      Filter newFilter = combineFilters(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues),
-                                        scan.getFilter());
+      Filter newFilter = Filters.combine(getTransactionFilter(tx), scan.getFilter());
       scan.setFilter(newFilter);
     }
     return s;
@@ -203,14 +202,13 @@ public class TransactionDataJanitor extends BaseRegionObserver {
     return scanner;
   }
 
-  private Filter combineFilters(Filter overrideFilter, Filter baseFilter) {
-    if (baseFilter != null) {
-      FilterList filterList = new FilterList(FilterList.Operator.MUST_PASS_ALL);
-      filterList.addFilter(baseFilter);
-      filterList.addFilter(overrideFilter);
-      return filterList;
-    }
-    return overrideFilter;
+  /**
+   * Derived classes can override this method to customize the filter used to return data visible for the current
+   * transaction.
+   * @param tx The current transaction to apply.
+   */
+  protected Filter getTransactionFilter(Transaction tx) {
+    return new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues);
   }
 
   private DataJanitorRegionScanner createDataJanitorRegionScanner(ObserverContext<RegionCoprocessorEnvironment> e,

--- a/tephra-hbase-compat-0.98/src/main/java/com/continuuity/tephra/coprocessor/hbase98/TransactionVisibilityFilter.java
+++ b/tephra-hbase-compat-0.98/src/main/java/com/continuuity/tephra/coprocessor/hbase98/TransactionVisibilityFilter.java
@@ -21,11 +21,13 @@ import com.continuuity.tephra.TxConstants;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterBase;
 import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.IOException;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Applies filtering of data based on transactional visibility (HBase 0.98+ specific version).
@@ -38,12 +40,38 @@ public class TransactionVisibilityFilter extends FilterBase {
   private final Map<byte[], Long> oldestTsByFamily;
   // if false, empty values will be interpreted as deletes
   private final boolean allowEmptyValues;
+  // optional sub-filter to apply to visible cells
+  private final Filter cellFilter;
 
   // since we traverse KVs in order, cache the current oldest TS to avoid map lookups per KV
   private byte[] currentFamily = new byte[0];
   private long currentOldestTs;
 
+  /**
+   * Creates a new {@link org.apache.hadoop.hbase.filter.Filter} for returning data only from visible transactions.
+   *
+   * @param tx The current transaction to apply.  Only data visible to this transaction will be returned.
+   * @param ttlByFamily Map of time-to-live (TTL) (in milliseconds) by column family name.
+   * @param allowEmptyValues If {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
+   *                         these will be interpreted as "delete" markers and the column will be filtered out.
+   */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues) {
+    this(tx, ttlByFamily, allowEmptyValues, null);
+  }
+
+  /**
+   * Creates a new {@link org.apache.hadoop.hbase.filter.Filter} for returning data only from visible transactions.
+   *
+   * @param tx The current transaction to apply.  Only data visible to this transaction will be returned.
+   * @param ttlByFamily Map of time-to-live (TTL) (in milliseconds) by column family name.
+   * @param allowEmptyValues If {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
+   *                         these will be interpreted as "delete" markers and the column will be filtered out.
+   * @param cellFilter If non-null, this filter will be applied to all cells visible to the current transaction, by
+   *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
+   *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
+   */
+  public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
+                                     @Nullable Filter cellFilter) {
     this.tx = tx;
     this.oldestTsByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
     for (Map.Entry<byte[], Long> ttlEntry : ttlByFamily.entrySet()) {
@@ -52,10 +80,11 @@ public class TransactionVisibilityFilter extends FilterBase {
                            familyTTL <= 0 ? 0 : tx.getVisibilityUpperBound() - familyTTL * TxConstants.MAX_TX_PER_MS);
     }
     this.allowEmptyValues = allowEmptyValues;
+    this.cellFilter = cellFilter;
   }
 
   @Override
-  public ReturnCode filterKeyValue(Cell cell) {
+  public ReturnCode filterKeyValue(Cell cell) throws IOException {
     if (!CellUtil.matchingFamily(cell, currentFamily)) {
       // column family changed
       currentFamily = CellUtil.cloneFamily(cell);
@@ -72,8 +101,13 @@ public class TransactionVisibilityFilter extends FilterBase {
         // skip "deleted" cell
         return ReturnCode.NEXT_COL;
       }
-      // as soon as we find a KV to include we can move to the next column
-      return ReturnCode.INCLUDE_AND_NEXT_COL;
+      // cell is visible
+      if (cellFilter != null) {
+        return cellFilter.filterKeyValue(cell);
+      } else {
+        // as soon as we find a KV to include we can move to the next column
+        return ReturnCode.INCLUDE_AND_NEXT_COL;
+      }
     } else {
       return ReturnCode.SKIP;
     }

--- a/tephra-hbase-compat-0.98/src/main/java/com/continuuity/tephra/hbase/Filters.java
+++ b/tephra-hbase-compat-0.98/src/main/java/com/continuuity/tephra/hbase/Filters.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2014 Continuuity, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.continuuity.tephra.hbase;
+
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+
+/**
+ * Utility methods for working with HBase filters.
+ */
+public final class Filters {
+  /**
+   * Adds {@code overrideFilter} on to {@code baseFilter}, if it exists, otherwise replaces it.
+   */
+  public static Filter combine(Filter overrideFilter, Filter baseFilter) {
+    if (baseFilter != null) {
+      FilterList filterList = new FilterList(FilterList.Operator.MUST_PASS_ALL);
+      filterList.addFilter(baseFilter);
+      filterList.addFilter(overrideFilter);
+      return filterList;
+    }
+    return overrideFilter;
+  }
+}


### PR DESCRIPTION
This change adds support in TransactionVisibilityFilter for an additional filter to apply to visible cells.  This allows the subfilter to control the return code used for these cells (e.g. INCLUDE vs. INCLUDE_AND_NEXT_COL).

This also cleans up some filter handling and allows the TransactionVisibilityFilter construction to be overridden in TransactionDataJanitor, so that other implementations can take advantage of the additional filtering.
