### PR TITLE
TEPHRA-9 Use transaction filter instead of wrapping scanner on flush and compact

### DIFF
--- a/tephra-hbase-compat-0.94/src/main/java/com/continuuity/tephra/hbase94/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-0.94/src/main/java/com/continuuity/tephra/hbase94/coprocessor/TransactionProcessor.java
@@ -31,6 +31,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Get;
@@ -39,15 +40,24 @@ import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.StoreScanner;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 
+import java.io.DataInput;
+import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -66,7 +76,7 @@ import java.util.Set;
  * {@code
  * <property>
  *   <name>hbase.coprocessor.region.classes</name>
- *   <value>com.continuuity.tephra.coprocessor.hbase94.TransactionDataJanitor</value>
+ *   <value>com.continuuity.tephra.hbase94.coprocessor.TransactionProcessor</value>
  * </property>
  * }
  * </p>
@@ -109,6 +119,7 @@ public class TransactionProcessor extends BaseRegionObserver {
         if (columnTTL != null) {
           try {
             ttl = Long.parseLong(columnTTL);
+            LOG.info("Family " + columnDesc.getNameAsString() + " has TTL of " + columnTTL);
           } catch (NumberFormatException nfe) {
             LOG.warn("Invalid TTL value configured for column family " + columnDesc.getNameAsString() +
                        ", value = " + columnTTL);
@@ -163,45 +174,48 @@ public class TransactionProcessor extends BaseRegionObserver {
   }
 
   @Override
-  public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
-      InternalScanner scanner) throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    if (snapshot != null) {
-      return createDataJanitorRegionScanner(e, store, scanner, snapshot);
-    }
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Region " + e.getEnvironment().getRegion().getRegionNameAsString() +
-                  ", no current transaction state found, defaulting to normal flush scanner");
-    }
-    return scanner;
+  public InternalScanner preFlushScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                             KeyValueScanner memstoreScanner, InternalScanner s)
+      throws IOException {
+    return createStoreScanner(c.getEnvironment(), "flush", cache.getLatestState(), store,
+                              Collections.singletonList(memstoreScanner), ScanType.MINOR_COMPACT,
+                              HConstants.OLDEST_TIMESTAMP);
   }
 
   @Override
-  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
-      InternalScanner scanner) throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    if (snapshot != null) {
-      return createDataJanitorRegionScanner(e, store, scanner, snapshot);
-    }
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Region " + e.getEnvironment().getRegion().getRegionNameAsString() +
-                  ", no current transaction state found, defaulting to normal compaction scanner");
-    }
-    return scanner;
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+      List<? extends KeyValueScanner> scanners, ScanType scanType, long earliestPutTs, InternalScanner s,
+      CompactionRequest request)
+    throws IOException {
+    return createStoreScanner(c.getEnvironment(), "compaction", cache.getLatestState(), store, scanners, scanType,
+                              earliestPutTs);
   }
 
-  @Override
-  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
-      InternalScanner scanner, CompactionRequest request) throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    if (snapshot != null) {
-      return createDataJanitorRegionScanner(e, store, scanner, snapshot);
+  protected InternalScanner createStoreScanner(RegionCoprocessorEnvironment env, String action,
+                                               TransactionSnapshot snapshot, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType type,
+                                               long earliestPutTs) throws IOException {
+    if (snapshot == null) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Region " + env.getRegion().getRegionNameAsString() +
+                    ", no current transaction state found, defaulting to normal compaction scanner");
+      }
+      return null;
     }
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Region " + e.getEnvironment().getRegion().getRegionNameAsString() +
-                  ", no current transaction state found, defaulting to normal compaction scanner");
-    }
-    return scanner;
+
+    // construct a dummy transaction from the latest snapshot
+    Transaction dummyTx = TxUtils.createDummyTransaction(snapshot);
+    Scan scan = new Scan();
+    // does not current support max versions setting per family
+    scan.setMaxVersions(dummyTx.excludesSize() + 1);
+    FilterList filterList = new FilterList(FilterList.Operator.MUST_PASS_ONE);
+    filterList.addFilter(getTransactionFilter(dummyTx));
+    filterList.addFilter(new IncludeInProgressFilter(dummyTx.getVisibilityUpperBound(),
+                                                     snapshot.getInvalid()));
+    scan.setFilter(filterList);
+
+    return new StoreScanner(store, store.getScanInfo(), scan, scanners, type,
+                            env.getRegion().getSmallestReadPoint(), earliestPutTs);
   }
 
   /**
@@ -213,126 +227,36 @@ public class TransactionProcessor extends BaseRegionObserver {
     return new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues);
   }
 
-  private DataJanitorRegionScanner createDataJanitorRegionScanner(ObserverContext<RegionCoprocessorEnvironment> e,
-                                                                  Store store,
-                                                                  InternalScanner scanner,
-                                                                  TransactionSnapshot snapshot) {
-    long visibilityUpperBound = snapshot.getVisibilityUpperBound();
-    String ttlProp = store.getFamily().getValue(TxConstants.PROPERTY_TTL);
-    int ttl = ttlProp == null ? -1 : Integer.valueOf(ttlProp);
-    // NOTE: to make sure we do not cleanup smth visible to tx in between its reads,
-    // we use visibilityUpperBound as current ts
-    long oldestToKeep = ttl <= 0 ? -1 : visibilityUpperBound - ttl * TxConstants.MAX_TX_PER_MS;
-
-    return new DataJanitorRegionScanner(visibilityUpperBound, oldestToKeep,
-                                        snapshot.getInvalid(), scanner,
-                                        e.getEnvironment().getRegion().getRegionName());
-  }
-
   /**
-   * Wraps the {@link org.apache.hadoop.hbase.regionserver.InternalScanner} instance used during compaction
-   * to filter out any {@link org.apache.hadoop.hbase.KeyValue} entries associated with invalid transactions.
+   * Filter used to include cells visible to in-progress transactions on flush and commit.
    */
-  static class DataJanitorRegionScanner implements InternalScanner {
+  static class IncludeInProgressFilter extends FilterBase {
     private final long visibilityUpperBound;
-    // oldest tx to keep based on ttl
-    private final long oldestToKeep;
     private final Set<Long> invalidIds;
-    private final InternalScanner internalScanner;
-    private final List<KeyValue> internalResults = new ArrayList<KeyValue>();
-    private final byte[] regionName;
-    private long expiredFilteredCount = 0L;
-    private long invalidFilteredCount = 0L;
-    // old and redundant: no tx will ever read them
-    private long oldFilteredCount = 0L;
 
-    public DataJanitorRegionScanner(long visibilityUpperBound, long oldestToKeep, Collection<Long> invalidSet,
-                                    InternalScanner scanner, byte[] regionName) {
-      this.visibilityUpperBound = visibilityUpperBound;
-      this.oldestToKeep = oldestToKeep;
-      this.invalidIds = Sets.newHashSet(invalidSet);
-      this.internalScanner = scanner;
-      this.regionName = regionName;
-      LOG.info("Created new scanner with visibilityUpperBound: " + visibilityUpperBound +
-                 ", invalid set: " + invalidIds + ", oldestToKeep: " + oldestToKeep);
+    public IncludeInProgressFilter(long upperBound, Collection<Long> invalids) {
+      this.visibilityUpperBound = upperBound;
+      this.invalidIds = Sets.newHashSet(invalids);
     }
 
     @Override
-    public boolean next(List<KeyValue> results) throws IOException {
-      return next(results, -1, null);
-    }
-
-    @Override
-    public boolean next(List<KeyValue> results, String metric) throws IOException {
-      return next(results, -1, metric);
-    }
-
-    @Override
-    public boolean next(List<KeyValue> results, int limit) throws IOException {
-      return next(results, limit, null);
-    }
-
-    @Override
-    public boolean next(List<KeyValue> results, int limit, String metric) throws IOException {
-      internalResults.clear();
-
-      boolean hasMore = internalScanner.next(internalResults, limit, metric);
-      // TODO: due to filtering our own results may be smaller than limit, so we should retry if needed to hit it
-
-      KeyValue previousKv = null;
-      // tells to skip those equal to current cell in case when we met one that is not newer than the oldest of
-      // currently used readPointers
-      boolean skipSameCells = false;
-
-      for (KeyValue kv : internalResults) {
-        // filter out by ttl
-        if (kv.getTimestamp() < oldestToKeep) {
-          expiredFilteredCount++;
-          continue;
-        }
-
-        // filter out any KeyValue with a timestamp matching an invalid write pointer
-        if (invalidIds.contains(kv.getTimestamp())) {
-          invalidFilteredCount++;
-          continue;
-        }
-
-        boolean sameAsPreviousCell = previousKv != null && sameCell(kv, previousKv);
-        // TODO: should check if this is a delete (empty byte[]) and !allowEmptyValues, then drop and skip to next col
-        // skip same as previous if told so
-        if (sameAsPreviousCell && skipSameCells) {
-          oldFilteredCount++;
-          continue;
-        }
-
-        // at this point we know we want to include it
-        results.add(kv);
-
-        if (!sameAsPreviousCell) {
-          // this cell is different from previous, resetting state
-          previousKv = kv;
-        }
-
-        // we met at least one version that is not newer than the oldest of currently used readPointers hence we
-        // can skip older ones
-        skipSameCells = kv.getTimestamp() <= visibilityUpperBound;
+    public ReturnCode filterKeyValue(KeyValue cell) {
+      // include all cells visible to in-progress transactions, except for those already marked as invalid
+      long ts = cell.getTimestamp();
+      if (ts > visibilityUpperBound && !invalidIds.contains(ts)) {
+        return ReturnCode.INCLUDE;
       }
-
-      return hasMore;
-    }
-
-    private boolean sameCell(KeyValue first, KeyValue second) {
-      return first.matchingRow(second) &&
-        first.matchingFamily(second) &&
-        first.matchingQualifier(second);
+      return ReturnCode.SKIP;
     }
 
     @Override
-    public void close() throws IOException {
-      LOG.info("Region " + Bytes.toStringBinary(regionName) +
-                 " filtered out invalid/old/expired "
-                 + invalidFilteredCount + "/" + oldFilteredCount + "/" + expiredFilteredCount + " KeyValues");
-      this.internalScanner.close();
+    public void write(DataOutput dataOutput) throws IOException {
+      throw new UnsupportedOperationException("IncludeInProgressFilter only intended for server-side use.");
+    }
+
+    @Override
+    public void readFields(DataInput dataInput) throws IOException {
+      throw new UnsupportedOperationException("IncludeInProgressFilter only intended for server-side use.");
     }
   }
 }

--- a/tephra-hbase-compat-0.94/src/test/java/com/continuuity/tephra/hbase94/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.94/src/test/java/com/continuuity/tephra/hbase94/coprocessor/TransactionProcessorTest.java
@@ -106,9 +106,9 @@ public class TransactionProcessorTest {
     // write an initial transaction snapshot
     TransactionSnapshot snapshot =
       TransactionSnapshot.copyFrom(
-        System.currentTimeMillis(), V[6], V[7], invalidSet,
+        System.currentTimeMillis(), V[6] - 1, V[7], invalidSet,
         // this will set visibility upper bound to V[6]
-        Maps.newTreeMap(ImmutableSortedMap.of(5L, new TransactionManager.InProgressTx(V[6], Long.MAX_VALUE))),
+        Maps.newTreeMap(ImmutableSortedMap.of(V[6], new TransactionManager.InProgressTx(V[6] - 1, Long.MAX_VALUE))),
         new HashMap<Long, Set<ChangeId>>(), new TreeMap<Long, Set<ChangeId>>());
     HDFSTransactionStateStorage tmpStorage =
       new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf));
@@ -158,53 +158,13 @@ public class TransactionProcessorTest {
 
       List<KeyValue> results = Lists.newArrayList();
 
-      // use the custom scanner to filter out results with timestamps in the invalid set
-      Scan scan = new Scan();
-      scan.setMaxVersions(10);
-      // NOTE: v1 and v2 are expired based on ttl: they are older than visibilityUpperBound - 3 hour
-      //       v3, v5, v7 are invalid
-      TransactionProcessor.DataJanitorRegionScanner scanner =
-          new TransactionProcessor.DataJanitorRegionScanner(V[6], V[3], invalidSet, region.getScanner(scan),
-                                                              region.getRegionName());
-      results.clear();
-      // row "1" should be empty
-      assertTrue(scanner.next(results));
-      assertEquals(0, results.size());
-      // row "2" should be empty
-      assertTrue(scanner.next(results));
-      assertEquals(0, results.size());
-      // row "3" should be empty
-      assertTrue(scanner.next(results));
-      assertEquals(0, results.size());
-
-      // first returned value should be "4" with version "4"
-      results.clear();
-      assertTrue(scanner.next(results));
-      assertKeyValueMatches(results, 4, new long[] {V[4]});
-
-      results.clear();
-      assertTrue(scanner.next(results));
-      assertKeyValueMatches(results, 5, new long[] {V[4]});
-
-      results.clear();
-      assertTrue(scanner.next(results));
-      assertKeyValueMatches(results, 6, new long[] {V[6]});
-
-      results.clear();
-      assertTrue(scanner.next(results));
-      assertKeyValueMatches(results, 7, new long[] {V[6]});
-
-      results.clear();
-      assertFalse(scanner.next(results));
-      assertKeyValueMatches(results, 8, new long[] {V[8], V[6]});
-
       // force a flush to clear the data
       // during flush, the coprocessor should drop all KeyValues with timestamps in the invalid set
       LOG.info("Flushing region " + region.getRegionNameAsString());
       region.flushcache();
 
       // now a normal scan should only return the valid rows - testing that cleanup works on flush
-      scan = new Scan();
+      Scan scan = new Scan();
       scan.setMaxVersions(10);
       RegionScanner regionScanner = region.getScanner(scan);
 
@@ -219,15 +179,15 @@ public class TransactionProcessorTest {
 
       results.clear();
       assertTrue(regionScanner.next(results));
-      assertKeyValueMatches(results, 6, new long[] {V[6]});
+      assertKeyValueMatches(results, 6, new long[] {V[6], V[4]});
 
       results.clear();
       assertTrue(regionScanner.next(results));
-      assertKeyValueMatches(results, 7, new long[] {V[6]});
+      assertKeyValueMatches(results, 7, new long[] {V[6], V[4]});
 
       results.clear();
       assertFalse(regionScanner.next(results));
-      assertKeyValueMatches(results, 8, new long[] {V[8], V[6]});
+      assertKeyValueMatches(results, 8, new long[] {V[8], V[6], V[4]});
     } finally {
       region.close();
     }

--- a/tephra-hbase-compat-0.96/src/main/java/com/continuuity/tephra/hbase96/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-0.96/src/main/java/com/continuuity/tephra/hbase96/coprocessor/TransactionProcessor.java
@@ -27,12 +27,14 @@ import com.continuuity.tephra.util.TxUtils;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Longs;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Scan;
@@ -40,16 +42,21 @@ import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.filter.FilterList;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.StoreScanner;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -68,7 +75,7 @@ import java.util.Set;
  * {@code
  * <property>
  *   <name>hbase.coprocessor.region.classes</name>
- *   <value>com.continuuity.tephra.coprocessor.hbase96.TransactionDataJanitor</value>
+ *   <value>com.continuuity.tephra.hbase96.coprocessor.TransactionProcessor</value>
  * </property>
  * }
  * </p>
@@ -160,45 +167,48 @@ public class TransactionProcessor extends BaseRegionObserver {
   }
 
   @Override
-  public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
-      InternalScanner scanner) throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    if (snapshot != null) {
-      return createDataJanitorRegionScanner(e, store, scanner, snapshot);
-    }
-    //if (LOG.isDebugEnabled()) {
-      LOG.info("Region " + e.getEnvironment().getRegion().getRegionNameAsString() +
-                  ", no current transaction state found, defaulting to normal flush scanner");
-    //}
-    return scanner;
+  public InternalScanner preFlushScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                             KeyValueScanner memstoreScanner, InternalScanner scanner)
+      throws IOException {
+    return createStoreScanner(c.getEnvironment(), "flush", cache.getLatestState(), store,
+                              Collections.singletonList(memstoreScanner), ScanType.COMPACT_RETAIN_DELETES,
+                              HConstants.OLDEST_TIMESTAMP);
   }
 
   @Override
-  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
-      InternalScanner scanner, ScanType type) throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    if (snapshot != null) {
-      return createDataJanitorRegionScanner(e, store, scanner, snapshot);
-    }
-    //if (LOG.isDebugEnabled()) {
-      LOG.info("Region " + e.getEnvironment().getRegion().getRegionNameAsString() +
-                  ", no current transaction state found, defaulting to normal compaction scanner");
-    //}
-    return scanner;
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+      List<? extends KeyValueScanner> scanners, ScanType scanType, long earliestPutTs, InternalScanner s,
+      CompactionRequest request)
+      throws IOException {
+    return createStoreScanner(c.getEnvironment(), "compaction", cache.getLatestState(), store, scanners, scanType,
+                              earliestPutTs);
   }
 
-  @Override
-  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
-      InternalScanner scanner, ScanType type, CompactionRequest request) throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    if (snapshot != null) {
-      return createDataJanitorRegionScanner(e, store, scanner, snapshot);
+  protected InternalScanner createStoreScanner(RegionCoprocessorEnvironment env, String action,
+                                               TransactionSnapshot snapshot, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType type,
+                                               long earliestPutTs) throws IOException {
+    if (snapshot == null) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Region " + env.getRegion().getRegionNameAsString() +
+                    ", no current transaction state found, defaulting to normal " + action + " scanner");
+      }
+      return null;
     }
-    //if (LOG.isDebugEnabled()) {
-      LOG.info("Region " + e.getEnvironment().getRegion().getRegionNameAsString() +
-                  ", no current transaction state found, defaulting to normal compaction scanner");
-    //}
-    return scanner;
+
+    // construct a dummy transaction from the latest snapshot
+    Transaction dummyTx = TxUtils.createDummyTransaction(snapshot);
+    Scan scan = new Scan();
+    // does not current support max versions setting per family
+    scan.setMaxVersions(dummyTx.excludesSize() + 1);
+    FilterList filterList = new FilterList(FilterList.Operator.MUST_PASS_ONE);
+    filterList.addFilter(getTransactionFilter(dummyTx));
+    filterList.addFilter(new IncludeInProgressFilter(dummyTx.getVisibilityUpperBound(),
+                                                     snapshot.getInvalid()));
+    scan.setFilter(filterList);
+
+    return new StoreScanner(store, store.getScanInfo(), scan, scanners,
+                            type, store.getSmallestReadPoint(), earliestPutTs);
   }
 
   /**
@@ -210,122 +220,26 @@ public class TransactionProcessor extends BaseRegionObserver {
     return new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues);
   }
 
-  private DataJanitorRegionScanner createDataJanitorRegionScanner(ObserverContext<RegionCoprocessorEnvironment> e,
-                                                                  Store store,
-                                                                  InternalScanner scanner,
-                                                                  TransactionSnapshot snapshot) {
-    long visibilityUpperBound = snapshot.getVisibilityUpperBound();
-    String ttlProp = store.getFamily().getValue(TxConstants.PROPERTY_TTL);
-    int ttl = ttlProp == null ? -1 : Integer.valueOf(ttlProp);
-    // NOTE: to make sure we do not cleanup smth visible to tx in between its reads,
-    // we use visibilityUpperBound as current ts
-    long oldestToKeep = ttl <= 0 ? -1 : visibilityUpperBound - ttl * TxConstants.MAX_TX_PER_MS;
-
-    return new DataJanitorRegionScanner(visibilityUpperBound, oldestToKeep,
-                                        snapshot.getInvalid(), scanner,
-                                        e.getEnvironment().getRegion().getRegionName());
-  }
-
   /**
-   * Wraps the {@link org.apache.hadoop.hbase.regionserver.InternalScanner} instance used during compaction
-   * to filter out any {@link org.apache.hadoop.hbase.KeyValue} entries associated with invalid transactions.
+   * Filter used to include cells visible to in-progress transactions on flush and commit.
    */
-  static class DataJanitorRegionScanner implements InternalScanner {
+  static class IncludeInProgressFilter extends FilterBase {
     private final long visibilityUpperBound;
-    // oldest tx to keep based on ttl
-    private final long oldestToKeep;
     private final Set<Long> invalidIds;
-    private final InternalScanner internalScanner;
-    private final List<Cell> internalResults = new ArrayList<Cell>();
-    private final byte[] regionName;
-    private long expiredFilteredCount = 0L;
-    private long invalidFilteredCount = 0L;
-    // old and redundant: no tx will ever read them
-    private long oldFilteredCount = 0L;
 
-    public DataJanitorRegionScanner(long visibilityUpperBound, long oldestToKeep, Collection<Long> invalidSet,
-                                    InternalScanner scanner, byte[] regionName) {
-      this.visibilityUpperBound = visibilityUpperBound;
-      this.oldestToKeep = oldestToKeep;
-      this.invalidIds = Sets.newHashSet(invalidSet);
-      this.internalScanner = scanner;
-      this.regionName = regionName;
-      LOG.info("Created new scanner with visibilityUpperBound: " + visibilityUpperBound +
-                 ", invalid set: " + invalidIds + ", oldestToKeep: " + oldestToKeep);
+    public IncludeInProgressFilter(long upperBound, Collection<Long> invalids) {
+      this.visibilityUpperBound = upperBound;
+      this.invalidIds = Sets.newHashSet(invalids);
     }
 
     @Override
-    public boolean next(List<Cell> results) throws IOException {
-      return next(results, -1);
-    }
-
-    @Override
-    public boolean next(List<Cell> results, int limit) throws IOException {
-      results.clear();
-
-      boolean hasMore;
-      do {
-        internalResults.clear();
-        hasMore = internalScanner.next(internalResults, limit);
-        // TODO: due to filtering our own results may be smaller than limit, so we should retry if needed to hit it
-
-        Cell previousCell = null;
-        // tells to skip those equal to current cell in case when we met one that is not newer than the oldest of
-        // currently used readPointers
-        boolean skipSameCells = false;
-
-        for (Cell cell : internalResults) {
-          // filter out by ttl
-          if (cell.getTimestamp() < oldestToKeep) {
-            expiredFilteredCount++;
-            continue;
-          }
-
-          // filter out any KeyValue with a timestamp matching an invalid write pointer
-          if (invalidIds.contains(cell.getTimestamp())) {
-            invalidFilteredCount++;
-            continue;
-          }
-
-          boolean sameAsPreviousCell = previousCell != null && sameCell(cell, previousCell);
-
-          // TODO: should check if this is a delete (empty byte[]) and !allowEmptyValues, then drop and skip to next col
-          // skip same as previous if told so
-          if (sameAsPreviousCell && skipSameCells) {
-            oldFilteredCount++;
-            continue;
-          }
-
-          // at this point we know we want to include it
-          results.add(cell);
-
-          if (!sameAsPreviousCell) {
-            // this cell is different from previous, resetting state
-            previousCell = cell;
-          }
-
-          // we met at least one version that is not newer than the oldest of currently used readPointers hence we
-          // can skip older ones
-          skipSameCells = cell.getTimestamp() <= visibilityUpperBound;
-        }
-
-      } while (results.isEmpty() && hasMore);
-
-      return hasMore;
-    }
-
-    private boolean sameCell(Cell first, Cell second) {
-      return CellComparator.equalsRow(first, second) &&
-        CellComparator.equalsFamily(first, second) &&
-        CellComparator.equalsQualifier(first, second);
-    }
-
-    @Override
-    public void close() throws IOException {
-      LOG.info("Region " + Bytes.toStringBinary(regionName) +
-                 " filtered out invalid/old/expired "
-                 + invalidFilteredCount + "/" + oldFilteredCount + "/" + expiredFilteredCount + " KeyValues");
-      this.internalScanner.close();
+    public ReturnCode filterKeyValue(Cell cell) throws IOException {
+      // include all cells visible to in-progress transactions, except for those already marked as invalid
+      long ts = cell.getTimestamp();
+      if (ts > visibilityUpperBound && !invalidIds.contains(ts)) {
+        return ReturnCode.INCLUDE;
+      }
+      return ReturnCode.SKIP;
     }
   }
 }

--- a/tephra-hbase-compat-0.98/src/test/java/com/continuuity/tephra/hbase98/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/com/continuuity/tephra/hbase98/coprocessor/TransactionProcessorTest.java
@@ -102,7 +102,7 @@ public class TransactionProcessorTest {
     long now = System.currentTimeMillis();
     V = new long[9];
     for (int i = 0; i < V.length; i++) {
-      V[i] = (now - TimeUnit.HOURS.toMillis(9 - i)) * TxConstants.MAX_TX_PER_MS;
+      V[i] = (now - TimeUnit.HOURS.toMillis(8 - i)) * TxConstants.MAX_TX_PER_MS;
     }
   }
 
@@ -130,9 +130,9 @@ public class TransactionProcessorTest {
     // write an initial transaction snapshot
     TransactionSnapshot snapshot =
       TransactionSnapshot.copyFrom(
-        System.currentTimeMillis(), V[6], V[7], invalidSet,
+        System.currentTimeMillis(), V[6] - 1, V[7], invalidSet,
         // this will set visibility upper bound to V[6]
-        Maps.newTreeMap(ImmutableSortedMap.of(5L, new TransactionManager.InProgressTx(V[6], Long.MAX_VALUE))),
+        Maps.newTreeMap(ImmutableSortedMap.of(V[6], new TransactionManager.InProgressTx(V[6] - 1, Long.MAX_VALUE))),
         new HashMap<Long, Set<ChangeId>>(), new TreeMap<Long, Set<ChangeId>>());
     HDFSTransactionStateStorage tmpStorage =
       new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf));
@@ -183,43 +183,13 @@ public class TransactionProcessorTest {
 
       List<Cell> results = Lists.newArrayList();
 
-      // use the custom scanner to filter out results with timestamps in the invalid set
-      Scan scan = new Scan();
-      scan.setMaxVersions(10);
-      // NOTE: v1 and v2 are expired based on ttl: they are older than visibilityUpperBound - 3 hour
-      //       v3, v5, v7 are invalid
-      TransactionProcessor.DataJanitorRegionScanner scanner =
-        new TransactionProcessor.DataJanitorRegionScanner(V[6], V[3], invalidSet, region.getScanner(scan),
-                                                            region.getRegionName());
-
-      // first returned value should be "4" with version "4"
-      results.clear();
-      assertTrue(scanner.next(results));
-      assertKeyValueMatches(results, 4, new long[] {V[4]});
-
-      results.clear();
-      assertTrue(scanner.next(results));
-      assertKeyValueMatches(results, 5, new long[] {V[4]});
-
-      results.clear();
-      assertTrue(scanner.next(results));
-      assertKeyValueMatches(results, 6, new long[] {V[6]});
-
-      results.clear();
-      assertTrue(scanner.next(results));
-      assertKeyValueMatches(results, 7, new long[] {V[6]});
-
-      results.clear();
-      assertFalse(scanner.next(results));
-      assertKeyValueMatches(results, 8, new long[] {V[8], V[6]});
-
       // force a flush to clear the data
       // during flush, the coprocessor should drop all KeyValues with timestamps in the invalid set
       LOG.info("Flushing region " + region.getRegionNameAsString());
       region.flushcache();
 
       // now a normal scan should only return the valid rows - testing that cleanup works on flush
-      scan = new Scan();
+      Scan scan = new Scan();
       scan.setMaxVersions(10);
       RegionScanner regionScanner = region.getScanner(scan);
 
@@ -234,15 +204,15 @@ public class TransactionProcessorTest {
 
       results.clear();
       assertTrue(regionScanner.next(results));
-      assertKeyValueMatches(results, 6, new long[] {V[6]});
+      assertKeyValueMatches(results, 6, new long[] {V[6], V[4]});
 
       results.clear();
       assertTrue(regionScanner.next(results));
-      assertKeyValueMatches(results, 7, new long[] {V[6]});
+      assertKeyValueMatches(results, 7, new long[] {V[6], V[4]});
 
       results.clear();
       assertFalse(regionScanner.next(results));
-      assertKeyValueMatches(results, 8, new long[] {V[8], V[6]});
+      assertKeyValueMatches(results, 8, new long[] {V[8], V[6], V[4]});
     } finally {
       region.close();
     }


### PR DESCRIPTION
This replaces use of DataJanitorRegionScanner (which wrapped the InternalScanner used on flush and compaction) with use of TransactionVisibilityFilter using the latest transaction snapshot's state.  In order for cells needed by in-progress transactions to remain visible, this also adds an IncludeInProgressFilter, which simply removes cells belonging to invalid transactions from anything appearing above the visibility upper bound.

Overall this simplifies the code, and makes it so that flush and compaction filtering correctly works with the ability to use a sub-filter for visible cells.

In addition, I cleaned up a few issues with the TransactionProcessorTest test.
