### PR TITLE
Use correct config for transaction state storage

### DIFF
--- a/tephra-core/src/main/java/com/continuuity/tephra/coprocessor/TransactionStateCache.java
+++ b/tephra-core/src/main/java/com/continuuity/tephra/coprocessor/TransactionStateCache.java
@@ -99,7 +99,7 @@ public class TransactionStateCache extends AbstractIdleService implements Config
   }
 
   protected Configuration getSnapshotConfiguration() throws IOException {
-    Configuration conf = HBaseConfiguration.create();
+    Configuration conf = HBaseConfiguration.create(hConf);
     conf.unset(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES);
     return conf;
   }

--- a/tephra-core/src/main/java/com/continuuity/tephra/coprocessor/TransactionStateCacheSupplier.java
+++ b/tephra-core/src/main/java/com/continuuity/tephra/coprocessor/TransactionStateCacheSupplier.java
@@ -44,7 +44,7 @@ public class TransactionStateCacheSupplier implements Supplier<TransactionStateC
         if (instance == null) {
           instance = new TransactionStateCache();
           instance.setConf(conf);
-          instance.startAndWait();
+          instance.start();
         }
       }
     }


### PR DESCRIPTION
TransactionStateCache allows the configuration used to be overridable, but was using the wrong instance.
