### PR TITLE
TEPHRA-11 Fix FilterList exception thrown in flush and compaction when deletes are present

### DIFF
--- a/tephra-hbase-compat-0.94/src/main/java/com/continuuity/tephra/hbase94/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-0.94/src/main/java/com/continuuity/tephra/hbase94/coprocessor/TransactionProcessor.java
@@ -41,8 +41,6 @@ import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterBase;
-import org.apache.hadoop.hbase.filter.FilterList;
-import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
@@ -55,7 +53,6 @@ import org.apache.hadoop.hbase.util.Bytes;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -198,7 +195,7 @@ public class TransactionProcessor extends BaseRegionObserver {
     if (snapshot == null) {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Region " + env.getRegion().getRegionNameAsString() +
-                    ", no current transaction state found, defaulting to normal compaction scanner");
+                    ", no current transaction state found, defaulting to normal " + action + " scanner");
       }
       return null;
     }
@@ -208,11 +205,9 @@ public class TransactionProcessor extends BaseRegionObserver {
     Scan scan = new Scan();
     // does not current support max versions setting per family
     scan.setMaxVersions(dummyTx.excludesSize() + 1);
-    FilterList filterList = new FilterList(FilterList.Operator.MUST_PASS_ONE);
-    filterList.addFilter(getTransactionFilter(dummyTx));
-    filterList.addFilter(new IncludeInProgressFilter(dummyTx.getVisibilityUpperBound(),
-                                                     snapshot.getInvalid()));
-    scan.setFilter(filterList);
+    scan.setFilter(new IncludeInProgressFilter(dummyTx.getVisibilityUpperBound(),
+                                               snapshot.getInvalid(),
+                                               getTransactionFilter(dummyTx)));
 
     return new StoreScanner(store, store.getScanInfo(), scan, scanners, type,
                             env.getRegion().getSmallestReadPoint(), earliestPutTs);
@@ -233,20 +228,26 @@ public class TransactionProcessor extends BaseRegionObserver {
   static class IncludeInProgressFilter extends FilterBase {
     private final long visibilityUpperBound;
     private final Set<Long> invalidIds;
+    private final Filter txFilter;
 
-    public IncludeInProgressFilter(long upperBound, Collection<Long> invalids) {
+    public IncludeInProgressFilter(long upperBound, Collection<Long> invalids, Filter transactionFilter) {
       this.visibilityUpperBound = upperBound;
       this.invalidIds = Sets.newHashSet(invalids);
+      this.txFilter = transactionFilter;
     }
 
     @Override
     public ReturnCode filterKeyValue(KeyValue cell) {
       // include all cells visible to in-progress transactions, except for those already marked as invalid
       long ts = cell.getTimestamp();
-      if (ts > visibilityUpperBound && !invalidIds.contains(ts)) {
+      if (ts > visibilityUpperBound) {
+        // include everything that could still be in-progress except invalids
+        if (invalidIds.contains(ts)) {
+          return ReturnCode.SKIP;
+        }
         return ReturnCode.INCLUDE;
       }
-      return ReturnCode.SKIP;
+      return txFilter.filterKeyValue(cell);
     }
 
     @Override

--- a/tephra-hbase-compat-0.96/src/test/java/com/continuuity/tephra/hbase96/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/com/continuuity/tephra/hbase96/coprocessor/TransactionProcessorTest.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.catalog.CatalogTracker;
+import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.executor.ExecutorService;
@@ -211,6 +212,63 @@ public class TransactionProcessorTest {
       results.clear();
       assertFalse(regionScanner.next(results));
       assertKeyValueMatches(results, 8, new long[] {V[8], V[6], V[4]});
+    } finally {
+      region.close();
+    }
+  }
+
+  @Test
+  public void testDeleteFiltering() throws Exception {
+    String tableName = "TestDeleteFiltering";
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    HTableDescriptor htd = new HTableDescriptor(TableName.valueOf(tableName));
+    HColumnDescriptor cfd = new HColumnDescriptor(familyBytes);
+    cfd.setMaxVersions(10);
+    htd.addFamily(cfd);
+    htd.addCoprocessor(TransactionProcessor.class.getName());
+    Path tablePath = new Path("/tmp/" + tableName);
+    Path hlogPath = new Path("/tmp/hlog");
+    Configuration hConf = conf;
+    FileSystem fs = FileSystem.get(hConf);
+    assertTrue(fs.mkdirs(tablePath));
+    HLog hLog = HLogFactory.createHLog(fs, hlogPath, "testDeleteFiltering", hConf);
+    HRegionInfo regionInfo = new HRegionInfo(TableName.valueOf(tableName));
+    HRegionFileSystem regionFS = HRegionFileSystem.createRegionOnFileSystem(hConf, fs, tablePath, regionInfo);
+    HRegion region = new HRegion(regionFS, hLog, hConf, htd, new MockRegionServerServices(hConf, null));
+    try {
+      region.initialize();
+      TransactionStateCache cache = new TransactionStateCacheSupplier(hConf).get();
+      LOG.info("Coprocessor is using transaction state: " + cache.getLatestState());
+
+      byte[] row = Bytes.toBytes(1);
+      for (int i = 4; i < V.length; i++) {
+        if (i != 5) {
+          Put p = new Put(row);
+          p.add(familyBytes, columnBytes, V[i], Bytes.toBytes(V[i]));
+          region.put(p);
+        }
+      }
+
+      // delete from the third entry back
+      Delete d = new Delete(row, V[5]);
+      region.delete(d);
+
+      List<Cell> results = Lists.newArrayList();
+
+      // force a flush to clear the data
+      // during flush, we should drop the deleted version, but not the others
+      LOG.info("Flushing region " + region.getRegionNameAsString());
+      region.flushcache();
+
+      // now a normal scan should return row with versions at: V[8], V[6].
+      // V[7] is invalid and V[5] and prior are deleted.
+      Scan scan = new Scan();
+      scan.setMaxVersions(10);
+      RegionScanner regionScanner = region.getScanner(scan);
+      // should be only one row
+      assertFalse(regionScanner.next(results));
+      assertKeyValueMatches(results, 1, new long[]{ V[8], V[6] });
     } finally {
       region.close();
     }


### PR DESCRIPTION
This replaces the use of FilterList in the StoreScanner returned for flush and compaction with only use of the Tephra transaction filters.  This eliminates the IllegalStateException thrown from FilterList when filterKeyValue() is not called for Delete cells.
