### PR TITLE
TEPHRA-43 TransactionVisibilityFilter can prematurely drop delete markers

### DIFF
--- a/tephra-hbase-compat-0.94/src/main/java/co/cask/tephra/hbase94/coprocessor/TransactionVisibilityFilter.java
+++ b/tephra-hbase-compat-0.94/src/main/java/co/cask/tephra/hbase94/coprocessor/TransactionVisibilityFilter.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.DataInput;
@@ -58,12 +59,11 @@ public class TransactionVisibilityFilter extends FilterBase {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
-   * @param clearDeletes whether this filter should drop "delete" markers (only safe when reading all store files,
-   *                     such as during a major compaction)
+   * @param scanType the type of scan operation being performed
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                                     boolean clearDeletes) {
-    this(tx, ttlByFamily, allowEmptyValues, clearDeletes, null);
+                                     ScanType scanType) {
+    this(tx, ttlByFamily, allowEmptyValues, scanType, null);
   }
 
   /**
@@ -73,14 +73,13 @@ public class TransactionVisibilityFilter extends FilterBase {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
-   * @param clearDeletes whether this filter should drop "delete" markers (only safe when reading all store files,
-   *                     such as during a major compaction)
+   * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.KeyValue)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                                     boolean clearDeletes, @Nullable Filter cellFilter) {
+                                     ScanType scanType, @Nullable Filter cellFilter) {
     this.tx = tx;
     this.oldestTsByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
     for (Map.Entry<byte[], Long> ttlEntry : ttlByFamily.entrySet()) {
@@ -89,7 +88,9 @@ public class TransactionVisibilityFilter extends FilterBase {
                            familyTTL <= 0 ? 0 : tx.getVisibilityUpperBound() - familyTTL * TxConstants.MAX_TX_PER_MS);
     }
     this.allowEmptyValues = allowEmptyValues;
-    this.clearDeletes = clearDeletes;
+    this.clearDeletes =
+        scanType == ScanType.MAJOR_COMPACT || scanType == ScanType.USER_SCAN;
+
     this.cellFilter = cellFilter;
   }
 

--- a/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/coprocessor/TransactionProcessorTest.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.wal.HLog;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.MockRegionServerServices;
@@ -306,7 +307,7 @@ public class TransactionProcessorTest {
       // read all back
       scan = new Scan(row);
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, true));
+          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       regionScanner = region.getScanner(scan);
       results = Lists.newArrayList();
       assertFalse(regionScanner.next(results));
@@ -328,7 +329,7 @@ public class TransactionProcessorTest {
 
       scan = new Scan(row);
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, true));
+          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       regionScanner = region.getScanner(scan);
       results = Lists.newArrayList();
       assertFalse(regionScanner.next(results));

--- a/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/coprocessor/TransactionVisibilityFilterTest.java
@@ -22,6 +22,7 @@ import co.cask.tephra.hbase.AbstractTransactionVisibilityFilterTest;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
 
@@ -34,11 +35,6 @@ import static org.junit.Assert.assertTrue;
  * HBase 0.94 specific test for filtering logic applied when reading data transactionally.
  */
 public class TransactionVisibilityFilterTest extends AbstractTransactionVisibilityFilterTest {
-  @Override
-  protected Filter createFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-    return new TransactionVisibilityFilter(tx, familyTTLs, false, true);
-  }
-
   /**
    * Test filtering of KeyValues for in-progress and invalid transactions.
    * @throws Exception
@@ -126,6 +122,11 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
                  filter.filterKeyValue(newKeyValue("row2", FAM, "val1", now)));
     assertEquals(Filter.ReturnCode.INCLUDE_AND_NEXT_COL,
                  filter.filterKeyValue(newKeyValue("row2", FAM, "val1", now - 1 * TxConstants.MAX_TX_PER_MS)));
+  }
+
+  @Override
+  protected Filter createFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
+    return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN);
   }
 
   protected KeyValue newKeyValue(String rowkey, String value, long timestamp) {

--- a/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/coprocessor/TransactionProcessorTest.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.hbase.regionserver.Leases;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.regionserver.RegionServerAccounting;
 import org.apache.hadoop.hbase.regionserver.RegionServerServices;
+import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.wal.HLog;
 import org.apache.hadoop.hbase.regionserver.wal.HLogFactory;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -298,7 +299,7 @@ public class TransactionProcessorTest {
       // read all back
       scan = new Scan(row);
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, true));
+          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       regionScanner = region.getScanner(scan);
       results = Lists.newArrayList();
       assertFalse(regionScanner.next(results));
@@ -320,7 +321,7 @@ public class TransactionProcessorTest {
 
       scan = new Scan(row);
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, true));
+          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       regionScanner = region.getScanner(scan);
       results = Lists.newArrayList();
       assertFalse(regionScanner.next(results));

--- a/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/coprocessor/TransactionVisibilityFilterTest.java
@@ -22,6 +22,7 @@ import co.cask.tephra.hbase.AbstractTransactionVisibilityFilterTest;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
 
@@ -125,7 +126,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
 
   @Override
   protected Filter createFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-    return new TransactionVisibilityFilter(tx, familyTTLs, false, true);
+    return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN);
   }
 
   protected KeyValue newKeyValue(String rowkey, String value, long timestamp) {

--- a/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessor.java
@@ -144,7 +144,7 @@ public class TransactionProcessor extends BaseRegionObserver {
     if (tx != null) {
       get.setMaxVersions(tx.excludesSize() + 1);
       get.setTimeRange(TxUtils.getOldestVisibleTimestamp(ttlByFamily, tx), TxUtils.getMaxVisibleTimestamp(tx));
-      Filter newFilter = Filters.combine(getTransactionFilter(tx, true), get.getFilter());
+      Filter newFilter = Filters.combine(getTransactionFilter(tx, ScanType.USER_SCAN), get.getFilter());
       get.setFilter(newFilter);
     }
   }
@@ -156,7 +156,7 @@ public class TransactionProcessor extends BaseRegionObserver {
     if (tx != null) {
       scan.setMaxVersions(tx.excludesSize() + 1);
       scan.setTimeRange(TxUtils.getOldestVisibleTimestamp(ttlByFamily, tx), TxUtils.getMaxVisibleTimestamp(tx));
-      Filter newFilter = Filters.combine(getTransactionFilter(tx, true), scan.getFilter());
+      Filter newFilter = Filters.combine(getTransactionFilter(tx, ScanType.USER_SCAN), scan.getFilter());
       scan.setFilter(newFilter);
     }
     return s;
@@ -200,8 +200,7 @@ public class TransactionProcessor extends BaseRegionObserver {
     scan.setFilter(
         new IncludeInProgressFilter(dummyTx.getVisibilityUpperBound(),
             snapshot.getInvalid(),
-            getTransactionFilter(dummyTx,
-                (type == ScanType.COMPACT_DROP_DELETES || type == ScanType.USER_SCAN))));
+            getTransactionFilter(dummyTx, type)));
 
     return new StoreScanner(store, store.getScanInfo(), scan, scanners,
                             type, store.getSmallestReadPoint(), earliestPutTs);
@@ -212,10 +211,10 @@ public class TransactionProcessor extends BaseRegionObserver {
    * transaction.
    *
    * @param tx the current transaction to apply
-   * @param clearDeletes whether delete markers can be dropped
+   * @param type the type of scan being performed
    */
-  protected Filter getTransactionFilter(Transaction tx, boolean clearDeletes) {
-    return new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, clearDeletes);
+  protected Filter getTransactionFilter(Transaction tx, ScanType type) {
+    return new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, type);
   }
 
   /**

--- a/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessorTest.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.hbase.regionserver.Leases;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.regionserver.RegionServerAccounting;
 import org.apache.hadoop.hbase.regionserver.RegionServerServices;
+import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.ServerNonceManager;
 import org.apache.hadoop.hbase.regionserver.wal.HLog;
 import org.apache.hadoop.hbase.regionserver.wal.HLogFactory;
@@ -301,7 +302,7 @@ public class TransactionProcessorTest {
       // read all back
       scan = new Scan(row);
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, true));
+          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       regionScanner = region.getScanner(scan);
       results = Lists.newArrayList();
       assertFalse(regionScanner.next(results));
@@ -323,7 +324,7 @@ public class TransactionProcessorTest {
 
       scan = new Scan(row);
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, true));
+          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       regionScanner = region.getScanner(scan);
       results = Lists.newArrayList();
       assertFalse(regionScanner.next(results));

--- a/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/coprocessor/TransactionVisibilityFilterTest.java
@@ -22,6 +22,7 @@ import co.cask.tephra.hbase.AbstractTransactionVisibilityFilterTest;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
 
@@ -125,7 +126,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
 
   @Override
   protected Filter createFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-    return new TransactionVisibilityFilter(tx, familyTTLs, false, true);
+    return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN);
   }
 
   protected KeyValue newKeyValue(String rowkey, String value, long timestamp) {


### PR DESCRIPTION
This fixes all versions of TransactionVisibilityFilter so that we only drop "delete" tombstones (Puts with empty values) when all store files are being read at the same time.  Makes the following changes:
- adds a flag to TransactionVisibilityFilter, set when doing a user scan or major compaction
- adds a test case that verifies "delete" tombstones are kept after a memstore flush
