### PR TITLE
TEPHRA-65 Transaction in progress should be able to read its own writes

### DIFF
--- a/tephra-core/src/main/java/co/cask/tephra/util/TxUtils.java
+++ b/tephra-core/src/main/java/co/cask/tephra/util/TxUtils.java
@@ -53,8 +53,8 @@ public class TxUtils {
    * @return The maximum timestamp (exclusive) to use for time-range operations
    */
   public static long getMaxVisibleTimestamp(Transaction tx) {
-    // NOTE: +1 here because we want read up to readpointer inclusive, but timerange's end is exclusive
-    return tx.getReadPointer() + 1;
+    // NOTE: +1 here because we want read up to writepointer inclusive, but timerange's end is exclusive
+    return tx.getWritePointer() + 1;
   }
 
   /**

--- a/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/TransactionAwareHTableTest.java
@@ -16,8 +16,16 @@
 package co.cask.tephra.hbase94;
 
 import co.cask.tephra.TransactionContext;
-import co.cask.tephra.inmemory.DetachedTxSystemClient;
+import co.cask.tephra.TransactionManager;
+import co.cask.tephra.hbase94.coprocessor.TransactionProcessor;
+import co.cask.tephra.inmemory.InMemoryTxSystemClient;
+import co.cask.tephra.metrics.TxMetricsCollector;
+import co.cask.tephra.persist.InMemoryTransactionStateStorage;
+import co.cask.tephra.persist.TransactionStateStorage;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
@@ -42,6 +50,9 @@ import java.io.IOException;
 public class TransactionAwareHTableTest {
   private static HBaseTestingUtility testUtil;
   private static HBaseAdmin hBaseAdmin;
+  private static TransactionStateStorage txStateStorage;
+  private static TransactionManager txManager;
+  private static Configuration conf;
   private TransactionContext transactionContext;
   private TransactionAwareHTable transactionAwareHTable;
 
@@ -57,7 +68,12 @@ public class TransactionAwareHTableTest {
   public static void setupBeforeClass() throws Exception {
     testUtil = new HBaseTestingUtility();
     testUtil.startMiniCluster();
+    conf = testUtil.getConfiguration();
     hBaseAdmin = testUtil.getHBaseAdmin();
+    txStateStorage = new InMemoryTransactionStateStorage();
+    txManager = new TransactionManager
+        (conf, txStateStorage, new TxMetricsCollector());
+    txManager.startAndWait();
   }
 
   @AfterClass
@@ -67,16 +83,27 @@ public class TransactionAwareHTableTest {
   }
 
   @Before
-  public void setupBeforeTest() throws IOException {
-    HTable hTable = testUtil.createTable(TestBytes.table, TestBytes.family);
+  public void setupBeforeTest() throws Exception {
+    HTable hTable = createTable(TestBytes.table, TestBytes.family);
     transactionAwareHTable = new TransactionAwareHTable(hTable);
-    transactionContext = new TransactionContext(new DetachedTxSystemClient(), transactionAwareHTable);
+    transactionContext = new TransactionContext(new InMemoryTxSystemClient(txManager), transactionAwareHTable);
   }
 
   @After
   public void shutdownAfterTest() throws IOException {
     hBaseAdmin.disableTable(TestBytes.table);
     hBaseAdmin.deleteTable(TestBytes.table);
+  }
+
+  private HTable createTable(byte[] tableName, byte[] columnFamily) throws Exception {
+    HTableDescriptor desc = new HTableDescriptor(tableName);
+    HColumnDescriptor columnDesc = new HColumnDescriptor(columnFamily);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    desc.addFamily(columnDesc);
+    desc.addCoprocessor(TransactionProcessor.class.getName());
+    hBaseAdmin.createTable(desc);
+    testUtil.waitTableAvailable(tableName, 5000);
+    return new HTable(testUtil.getConfiguration(), tableName);
   }
 
   /**
@@ -147,7 +174,7 @@ public class TransactionAwareHTableTest {
     result = transactionAwareHTable.get(new Get(TestBytes.row));
     transactionContext.finish();
     value = result.getValue(TestBytes.family, TestBytes.qualifier);
-    Assert.assertArrayEquals(value, new byte[0]);
+    Assert.assertNull(value);
   }
 
   /**
@@ -189,4 +216,65 @@ public class TransactionAwareHTableTest {
     transactionAwareHTable.get(new Get(TestBytes.row));
   }
 
+  /**
+   * Tests that each transaction can see its own persisted writes, while not seeing writes from other
+   * in-progress transactions.
+   */
+  @Test
+  public void testReadYourWrites() throws Exception {
+    // In-progress tx1: started before our main transaction
+    HTable hTable1 = new HTable(testUtil.getConfiguration(), TestBytes.table);
+    TransactionAwareHTable txHTable1 = new TransactionAwareHTable(hTable1);
+    TransactionContext inprogressTxContext1 = new TransactionContext(new InMemoryTxSystemClient(txManager), txHTable1);
+
+    // In-progress tx2: started while our main transaction is running
+    HTable hTable2 = new HTable(testUtil.getConfiguration(), TestBytes.table);
+    TransactionAwareHTable txHTable2 = new TransactionAwareHTable(hTable2);
+    TransactionContext inprogressTxContext2 = new TransactionContext(new InMemoryTxSystemClient(txManager), txHTable2);
+
+    // create an in-progress write that should be ignored
+    byte[] col2 = Bytes.toBytes("col2");
+    inprogressTxContext1.start();
+    Put putCol2 = new Put(TestBytes.row);
+    byte[] valueCol2 = Bytes.toBytes("writing in progress");
+    putCol2.add(TestBytes.family, col2, valueCol2);
+    txHTable1.put(putCol2);
+
+    // start a tx and write a value to test reading in same tx
+    transactionContext.start();
+    Put put = new Put(TestBytes.row);
+    byte[] value = Bytes.toBytes("writing");
+    put.add(TestBytes.family, TestBytes.qualifier, value);
+    transactionAwareHTable.put(put);
+
+    // test that a write from a tx started after the first is not visible
+    inprogressTxContext2.start();
+    Put put2 = new Put(TestBytes.row);
+    byte[] value2 = Bytes.toBytes("writing2");
+    put2.add(TestBytes.family, TestBytes.qualifier, value2);
+    txHTable2.put(put2);
+
+    Get get = new Get(TestBytes.row);
+    Result row = transactionAwareHTable.get(get);
+    Assert.assertFalse(row.isEmpty());
+    byte[] col1Value = row.getValue(TestBytes.family, TestBytes.qualifier);
+    Assert.assertNotNull(col1Value);
+    Assert.assertArrayEquals(value, col1Value);
+    // write from in-progress transaction should not be visible
+    byte[] col2Value = row.getValue(TestBytes.family, col2);
+    Assert.assertNull(col2Value);
+
+    // commit in-progress transaction, should still not be visible
+    inprogressTxContext1.finish();
+
+    get = new Get(TestBytes.row);
+    row = transactionAwareHTable.get(get);
+    Assert.assertFalse(row.isEmpty());
+    col2Value = row.getValue(TestBytes.family, col2);
+    Assert.assertNull(col2Value);
+
+    transactionContext.finish();
+
+    inprogressTxContext2.abort();
+  }
 }

--- a/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/TransactionAwareHTableTest.java
@@ -16,8 +16,17 @@
 package co.cask.tephra.hbase96;
 
 import co.cask.tephra.TransactionContext;
-import co.cask.tephra.inmemory.DetachedTxSystemClient;
+import co.cask.tephra.TransactionManager;
+import co.cask.tephra.hbase96.coprocessor.TransactionProcessor;
+import co.cask.tephra.inmemory.InMemoryTxSystemClient;
+import co.cask.tephra.metrics.TxMetricsCollector;
+import co.cask.tephra.persist.InMemoryTransactionStateStorage;
+import co.cask.tephra.persist.TransactionStateStorage;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
@@ -40,6 +49,9 @@ import java.io.IOException;
 public class TransactionAwareHTableTest {
   private static HBaseTestingUtility testUtil;
   private static HBaseAdmin hBaseAdmin;
+  private static TransactionStateStorage txStateStorage;
+  private static TransactionManager txManager;
+  private static Configuration conf;
   private TransactionContext transactionContext;
   private TransactionAwareHTable transactionAwareHTable;
 
@@ -55,7 +67,12 @@ public class TransactionAwareHTableTest {
   public static void setupBeforeClass() throws Exception {
     testUtil = new HBaseTestingUtility();
     testUtil.startMiniCluster();
+    conf = testUtil.getConfiguration();
     hBaseAdmin = testUtil.getHBaseAdmin();
+    txStateStorage = new InMemoryTransactionStateStorage();
+    txManager = new TransactionManager
+        (conf, txStateStorage, new TxMetricsCollector());
+    txManager.startAndWait();
   }
 
   @AfterClass
@@ -65,16 +82,27 @@ public class TransactionAwareHTableTest {
   }
 
   @Before
-  public void setupBeforeTest() throws IOException {
-    HTable hTable = testUtil.createTable(TestBytes.table, TestBytes.family);
+  public void setupBeforeTest() throws Exception {
+    HTable hTable = createTable(TestBytes.table, TestBytes.family);
     transactionAwareHTable = new TransactionAwareHTable(hTable);
-    transactionContext = new TransactionContext(new DetachedTxSystemClient(), transactionAwareHTable);
+    transactionContext = new TransactionContext(new InMemoryTxSystemClient(txManager), transactionAwareHTable);
   }
 
   @After
   public void shutdownAfterTest() throws IOException {
     hBaseAdmin.disableTable(TestBytes.table);
     hBaseAdmin.deleteTable(TestBytes.table);
+  }
+
+  private HTable createTable(byte[] tableName, byte[] columnFamily) throws Exception {
+    HTableDescriptor desc = new HTableDescriptor(TableName.valueOf(tableName));
+    HColumnDescriptor columnDesc = new HColumnDescriptor(columnFamily);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    desc.addFamily(columnDesc);
+    desc.addCoprocessor(TransactionProcessor.class.getName());
+    hBaseAdmin.createTable(desc);
+    testUtil.waitTableAvailable(tableName, 5000);
+    return new HTable(testUtil.getConfiguration(), tableName);
   }
 
   /**
@@ -145,7 +173,7 @@ public class TransactionAwareHTableTest {
     result = transactionAwareHTable.get(new Get(TestBytes.row));
     transactionContext.finish();
     value = result.getValue(TestBytes.family, TestBytes.qualifier);
-    Assert.assertArrayEquals(value, new byte[0]);
+    Assert.assertNull(value);
   }
 
   /**
@@ -187,4 +215,65 @@ public class TransactionAwareHTableTest {
     transactionAwareHTable.get(new Get(TestBytes.row));
   }
 
+  /**
+   * Tests that each transaction can see its own persisted writes, while not seeing writes from other
+   * in-progress transactions.
+   */
+  @Test
+  public void testReadYourWrites() throws Exception {
+    // In-progress tx1: started before our main transaction
+    HTable hTable1 = new HTable(testUtil.getConfiguration(), TestBytes.table);
+    TransactionAwareHTable txHTable1 = new TransactionAwareHTable(hTable1);
+    TransactionContext inprogressTxContext1 = new TransactionContext(new InMemoryTxSystemClient(txManager), txHTable1);
+
+    // In-progress tx2: started while our main transaction is running
+    HTable hTable2 = new HTable(testUtil.getConfiguration(), TestBytes.table);
+    TransactionAwareHTable txHTable2 = new TransactionAwareHTable(hTable2);
+    TransactionContext inprogressTxContext2 = new TransactionContext(new InMemoryTxSystemClient(txManager), txHTable2);
+
+    // create an in-progress write that should be ignored
+    byte[] col2 = Bytes.toBytes("col2");
+    inprogressTxContext1.start();
+    Put putCol2 = new Put(TestBytes.row);
+    byte[] valueCol2 = Bytes.toBytes("writing in progress");
+    putCol2.add(TestBytes.family, col2, valueCol2);
+    txHTable1.put(putCol2);
+
+    // start a tx and write a value to test reading in same tx
+    transactionContext.start();
+    Put put = new Put(TestBytes.row);
+    byte[] value = Bytes.toBytes("writing");
+    put.add(TestBytes.family, TestBytes.qualifier, value);
+    transactionAwareHTable.put(put);
+
+    // test that a write from a tx started after the first is not visible
+    inprogressTxContext2.start();
+    Put put2 = new Put(TestBytes.row);
+    byte[] value2 = Bytes.toBytes("writing2");
+    put2.add(TestBytes.family, TestBytes.qualifier, value2);
+    txHTable2.put(put2);
+
+    Get get = new Get(TestBytes.row);
+    Result row = transactionAwareHTable.get(get);
+    Assert.assertFalse(row.isEmpty());
+    byte[] col1Value = row.getValue(TestBytes.family, TestBytes.qualifier);
+    Assert.assertNotNull(col1Value);
+    Assert.assertArrayEquals(value, col1Value);
+    // write from in-progress transaction should not be visible
+    byte[] col2Value = row.getValue(TestBytes.family, col2);
+    Assert.assertNull(col2Value);
+
+    // commit in-progress transaction, should still not be visible
+    inprogressTxContext1.finish();
+
+    get = new Get(TestBytes.row);
+    row = transactionAwareHTable.get(get);
+    Assert.assertFalse(row.isEmpty());
+    col2Value = row.getValue(TestBytes.family, col2);
+    Assert.assertNull(col2Value);
+
+    transactionContext.finish();
+
+    inprogressTxContext2.abort();
+  }
 }

--- a/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/TransactionAwareHTableTest.java
@@ -16,8 +16,17 @@
 package co.cask.tephra.hbase98;
 
 import co.cask.tephra.TransactionContext;
-import co.cask.tephra.inmemory.DetachedTxSystemClient;
+import co.cask.tephra.TransactionManager;
+import co.cask.tephra.hbase98.coprocessor.TransactionProcessor;
+import co.cask.tephra.inmemory.InMemoryTxSystemClient;
+import co.cask.tephra.metrics.TxMetricsCollector;
+import co.cask.tephra.persist.InMemoryTransactionStateStorage;
+import co.cask.tephra.persist.TransactionStateStorage;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
@@ -40,6 +49,9 @@ import java.io.IOException;
 public class TransactionAwareHTableTest {
   private static HBaseTestingUtility testUtil;
   private static HBaseAdmin hBaseAdmin;
+  private static TransactionStateStorage txStateStorage;
+  private static TransactionManager txManager;
+  private static Configuration conf;
   private TransactionContext transactionContext;
   private TransactionAwareHTable transactionAwareHTable;
 
@@ -55,7 +67,12 @@ public class TransactionAwareHTableTest {
   public static void setupBeforeClass() throws Exception {
     testUtil = new HBaseTestingUtility();
     testUtil.startMiniCluster();
+    conf = testUtil.getConfiguration();
     hBaseAdmin = testUtil.getHBaseAdmin();
+    txStateStorage = new InMemoryTransactionStateStorage();
+    txManager = new TransactionManager
+        (conf, txStateStorage, new TxMetricsCollector());
+    txManager.startAndWait();
   }
 
   @AfterClass
@@ -65,16 +82,27 @@ public class TransactionAwareHTableTest {
   }
 
   @Before
-  public void setupBeforeTest() throws IOException {
-    HTable hTable = testUtil.createTable(TestBytes.table, TestBytes.family);
+  public void setupBeforeTest() throws Exception {
+    HTable hTable = createTable(TestBytes.table, TestBytes.family);
     transactionAwareHTable = new TransactionAwareHTable(hTable);
-    transactionContext = new TransactionContext(new DetachedTxSystemClient(), transactionAwareHTable);
+    transactionContext = new TransactionContext(new InMemoryTxSystemClient(txManager), transactionAwareHTable);
   }
 
   @After
   public void shutdownAfterTest() throws IOException {
     hBaseAdmin.disableTable(TestBytes.table);
     hBaseAdmin.deleteTable(TestBytes.table);
+  }
+
+  private HTable createTable(byte[] tableName, byte[] columnFamily) throws Exception {
+    HTableDescriptor desc = new HTableDescriptor(TableName.valueOf(tableName));
+    HColumnDescriptor columnDesc = new HColumnDescriptor(columnFamily);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    desc.addFamily(columnDesc);
+    desc.addCoprocessor(TransactionProcessor.class.getName());
+    hBaseAdmin.createTable(desc);
+    testUtil.waitTableAvailable(tableName, 5000);
+    return new HTable(testUtil.getConfiguration(), tableName);
   }
 
   /**
@@ -145,7 +173,7 @@ public class TransactionAwareHTableTest {
     result = transactionAwareHTable.get(new Get(TestBytes.row));
     transactionContext.finish();
     value = result.getValue(TestBytes.family, TestBytes.qualifier);
-    Assert.assertArrayEquals(value, new byte[0]);
+    Assert.assertNull(value);
   }
 
   /**
@@ -187,4 +215,65 @@ public class TransactionAwareHTableTest {
     transactionAwareHTable.get(new Get(TestBytes.row));
   }
 
+  /**
+   * Tests that each transaction can see its own persisted writes, while not seeing writes from other
+   * in-progress transactions.
+   */
+  @Test
+  public void testReadYourWrites() throws Exception {
+    // In-progress tx1: started before our main transaction
+    HTable hTable1 = new HTable(testUtil.getConfiguration(), TestBytes.table);
+    TransactionAwareHTable txHTable1 = new TransactionAwareHTable(hTable1);
+    TransactionContext inprogressTxContext1 = new TransactionContext(new InMemoryTxSystemClient(txManager), txHTable1);
+
+    // In-progress tx2: started while our main transaction is running
+    HTable hTable2 = new HTable(testUtil.getConfiguration(), TestBytes.table);
+    TransactionAwareHTable txHTable2 = new TransactionAwareHTable(hTable2);
+    TransactionContext inprogressTxContext2 = new TransactionContext(new InMemoryTxSystemClient(txManager), txHTable2);
+
+    // create an in-progress write that should be ignored
+    byte[] col2 = Bytes.toBytes("col2");
+    inprogressTxContext1.start();
+    Put putCol2 = new Put(TestBytes.row);
+    byte[] valueCol2 = Bytes.toBytes("writing in progress");
+    putCol2.add(TestBytes.family, col2, valueCol2);
+    txHTable1.put(putCol2);
+
+    // start a tx and write a value to test reading in same tx
+    transactionContext.start();
+    Put put = new Put(TestBytes.row);
+    byte[] value = Bytes.toBytes("writing");
+    put.add(TestBytes.family, TestBytes.qualifier, value);
+    transactionAwareHTable.put(put);
+
+    // test that a write from a tx started after the first is not visible
+    inprogressTxContext2.start();
+    Put put2 = new Put(TestBytes.row);
+    byte[] value2 = Bytes.toBytes("writing2");
+    put2.add(TestBytes.family, TestBytes.qualifier, value2);
+    txHTable2.put(put2);
+
+    Get get = new Get(TestBytes.row);
+    Result row = transactionAwareHTable.get(get);
+    Assert.assertFalse(row.isEmpty());
+    byte[] col1Value = row.getValue(TestBytes.family, TestBytes.qualifier);
+    Assert.assertNotNull(col1Value);
+    Assert.assertArrayEquals(value, col1Value);
+    // write from in-progress transaction should not be visible
+    byte[] col2Value = row.getValue(TestBytes.family, col2);
+    Assert.assertNull(col2Value);
+
+    // commit in-progress transaction, should still not be visible
+    inprogressTxContext1.finish();
+
+    get = new Get(TestBytes.row);
+    row = transactionAwareHTable.get(get);
+    Assert.assertFalse(row.isEmpty());
+    col2Value = row.getValue(TestBytes.family, col2);
+    Assert.assertNull(col2Value);
+
+    transactionContext.finish();
+
+    inprogressTxContext2.abort();
+  }
 }


### PR DESCRIPTION
Modifies the time range end used for reads to include the current transaction's write pointer and adds testing around write visibility.