### PR TITLE
TEPHRA-5 remove use of HBaseConfiguration in tephra-core

### DIFF
--- a/tephra-core/pom.xml
+++ b/tephra-core/pom.xml
@@ -97,11 +97,6 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase</artifactId>
-      <version>${hbase94.version}</version>
-    </dependency>
 
     <!-- Test dependencies -->
     <dependency>
@@ -111,12 +106,6 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minicluster</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase</artifactId>
-      <version>${hbase94.version}</version>
-      <classifier>tests</classifier>
     </dependency>
   </dependencies>
 

--- a/tephra-core/src/main/java/co/cask/tephra/TransactionServiceMain.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TransactionServiceMain.java
@@ -22,10 +22,10 @@ import co.cask.tephra.runtime.DiscoveryModules;
 import co.cask.tephra.runtime.TransactionClientModule;
 import co.cask.tephra.runtime.TransactionModules;
 import co.cask.tephra.runtime.ZKModule;
+import co.cask.tephra.util.ConfigurationFactory;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +90,7 @@ public class TransactionServiceMain {
    */
   public void init(String[] args) {
     if (conf == null) {
-      conf = HBaseConfiguration.create();
+      conf = new ConfigurationFactory().get();
     }
   }
 

--- a/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
@@ -231,6 +231,15 @@ public class TxConstants {
   }
 
   /**
+   * Configuration properties used by HBase
+   */
+  public static final class HBase {
+    public static final String ZOOKEEPER_QUORUM = "hbase.zookeeper.quorum";
+    public static final String ZK_SESSION_TIMEOUT = "zookeeper.session.timeout";
+    public static final int DEFAULT_ZK_SESSION_TIMEOUT = 180 * 1000;
+  }
+
+  /**
    * Configuration for the TransactionDataJanitor coprocessor.
    */
   public static final class DataJanitor {

--- a/tephra-core/src/main/java/co/cask/tephra/coprocessor/TransactionStateCache.java
+++ b/tephra-core/src/main/java/co/cask/tephra/coprocessor/TransactionStateCache.java
@@ -21,12 +21,12 @@ import co.cask.tephra.persist.HDFSTransactionStateStorage;
 import co.cask.tephra.persist.TransactionSnapshot;
 import co.cask.tephra.persist.TransactionStateStorage;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
+import co.cask.tephra.util.ConfigurationFactory;
 import com.google.common.util.concurrent.AbstractIdleService;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -99,7 +99,7 @@ public class TransactionStateCache extends AbstractIdleService implements Config
   }
 
   protected Configuration getSnapshotConfiguration() throws IOException {
-    Configuration conf = HBaseConfiguration.create(hConf);
+    Configuration conf = new ConfigurationFactory().get(hConf);
     conf.unset(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES);
     return conf;
   }

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/TransactionServiceClient.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/TransactionServiceClient.java
@@ -28,13 +28,13 @@ import co.cask.tephra.runtime.DiscoveryModules;
 import co.cask.tephra.runtime.TransactionClientModule;
 import co.cask.tephra.runtime.TransactionModules;
 import co.cask.tephra.runtime.ZKModule;
+import co.cask.tephra.util.ConfigurationFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.thrift.TException;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.slf4j.Logger;
@@ -72,7 +72,7 @@ public class TransactionServiceClient implements TransactionSystemClient {
     if (args.length == 1 && "-v".equals(args[0])) {
       verbose = true;
     }
-    doMain(verbose, HBaseConfiguration.create());
+    doMain(verbose, new ConfigurationFactory().get());
   }
 
   @VisibleForTesting

--- a/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionStateStorage.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionStateStorage.java
@@ -18,6 +18,7 @@ package co.cask.tephra.persist;
 
 import co.cask.tephra.TxConstants;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
+import co.cask.tephra.util.ConfigurationFactory;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -30,7 +31,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -372,7 +372,7 @@ public class HDFSTransactionStateStorage extends AbstractTransactionStateStorage
       printUsage("ERROR: Either -s or -l is required to set mode.", 1);
     }
 
-    Configuration config = HBaseConfiguration.create();
+    Configuration config = new ConfigurationFactory().get();
 
     HDFSTransactionStateStorage storage =
       new HDFSTransactionStateStorage(config, new SnapshotCodecProvider(config));

--- a/tephra-core/src/main/java/co/cask/tephra/runtime/ZKModule.java
+++ b/tephra-core/src/main/java/co/cask/tephra/runtime/ZKModule.java
@@ -21,7 +21,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.twill.zookeeper.RetryStrategies;
 import org.apache.twill.zookeeper.ZKClient;
 import org.apache.twill.zookeeper.ZKClientService;
@@ -50,14 +49,15 @@ public class ZKModule extends AbstractModule {
     String zkStr = conf.get(TxConstants.Service.CFG_DATA_TX_ZOOKEEPER_QUORUM);
     if (zkStr == null) {
       // Default to HBase one.
-      zkStr = conf.get(HConstants.ZOOKEEPER_QUORUM);
+      zkStr = conf.get(TxConstants.HBase.ZOOKEEPER_QUORUM);
     }
 
     return ZKClientServices.delegate(
       ZKClients.reWatchOnExpire(
         ZKClients.retryOnFailure(
           ZKClientService.Builder.of(zkStr)
-            .setSessionTimeout(conf.getInt(HConstants.ZK_SESSION_TIMEOUT, HConstants.DEFAULT_ZK_SESSION_TIMEOUT))
+            .setSessionTimeout(conf.getInt(TxConstants.HBase.ZK_SESSION_TIMEOUT,
+                TxConstants.HBase.DEFAULT_ZK_SESSION_TIMEOUT))
             .build(),
           RetryStrategies.exponentialDelay(500, 2000, TimeUnit.MILLISECONDS)
         )

--- a/tephra-core/src/main/java/co/cask/tephra/util/ConfigurationFactory.java
+++ b/tephra-core/src/main/java/co/cask/tephra/util/ConfigurationFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.util;
+
+import com.google.inject.Provider;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Provides {@code org.apache.hadoop.conf.Configuration} instances, constructed by the correct version used
+ * for the runtime.
+ */
+public class ConfigurationFactory implements Provider<Configuration> {
+  private static class ConfigurationProviderFactory extends HBaseVersionSpecificFactory<ConfigurationProvider> {
+    @Override
+    protected String getHBase94Classname() {
+      return "co.cask.tephra.hbase94.HBase94ConfigurationProvider";
+    }
+
+    @Override
+    protected String getHBase96Classname() {
+      return "co.cask.tephra.hbase96.HBase96ConfigurationProvider";
+    }
+
+    @Override
+    protected String getHBase98Classname() {
+      return "co.cask.tephra.hbase98.HBase98ConfigurationProvider";
+    }
+  }
+
+  private final ConfigurationProvider provider = new ConfigurationProviderFactory().get();
+
+  /**
+   * Returns a new {@link org.apache.hadoop.conf.Configuration} instance from the HBase version-specific factory.
+   */
+  @Override
+  public Configuration get() {
+    return provider.get();
+  }
+
+  /**
+   * Returns a new {@link org.apache.hadoop.conf.Configuration} instance from the HBase version-specific factory.
+   *
+   * @param baseConf additional configuration properties to merge on to the classpath configuration
+   * @return the merged configuration
+   */
+  public Configuration get(Configuration baseConf) {
+    return provider.get(baseConf);
+  }
+}

--- a/tephra-core/src/main/java/co/cask/tephra/util/ConfigurationProvider.java
+++ b/tephra-core/src/main/java/co/cask/tephra/util/ConfigurationProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.util;
+
+import com.google.inject.Provider;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Provides {@code Configuration} instances, constructed by the HBase version on which we are running.
+ */
+public abstract class ConfigurationProvider implements Provider<Configuration> {
+  @Override
+  public abstract Configuration get();
+
+  public abstract Configuration get(Configuration baseConf);
+}

--- a/tephra-core/src/main/java/co/cask/tephra/util/HBaseVersion.java
+++ b/tephra-core/src/main/java/co/cask/tephra/util/HBaseVersion.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+
+/**
+ * Detects the currently loaded HBase version.  It is assumed that only one HBase version is loaded at a time,
+ * since using more than one HBase version within the same process will require classloader isolation anyway.
+ */
+public class HBaseVersion {
+  private static final String HBASE_94_VERSION = "0.94";
+  private static final String HBASE_96_VERSION = "0.96";
+  private static final String HBASE_98_VERSION = "0.98";
+
+  private static final Logger LOG = LoggerFactory.getLogger(HBaseVersion.class);
+
+  /**
+   * Represents the major version of the HBase library that is currently loaded.
+   */
+  public enum Version {
+    HBASE_94("0.94"),
+    HBASE_96("0.96"),
+    HBASE_98("0.98"),
+    UNKNOWN("unknown");
+
+    final String majorVersion;
+
+    Version(String majorVersion) {
+      this.majorVersion = majorVersion;
+    }
+
+    public String getMajorVersion() {
+      return majorVersion;
+    }
+  }
+
+  private static Version currentVersion;
+  private static String versionString;
+  static {
+    try {
+      Class versionInfoClass = Class.forName("org.apache.hadoop.hbase.util.VersionInfo");
+      Method versionMethod = versionInfoClass.getMethod("getVersion");
+      versionString = (String) versionMethod.invoke(null);
+      if (versionString.startsWith(HBASE_94_VERSION)) {
+        currentVersion = Version.HBASE_94;
+      } else if (versionString.startsWith(HBASE_96_VERSION)) {
+        currentVersion = Version.HBASE_96;
+      } else if (versionString.startsWith(HBASE_98_VERSION)) {
+        currentVersion = Version.HBASE_98;
+      } else {
+        currentVersion = Version.UNKNOWN;
+      }
+    } catch (Throwable e) {
+      // must be a class loading exception, HBase is not there
+      LOG.error("Unable to determine HBase version from string '{}', are HBase classes available?", versionString);
+      LOG.error("Exception was: ", e);
+      currentVersion = Version.UNKNOWN;
+    }
+  }
+
+  /**
+   * Returns the major version of the currently loaded HBase library.
+   */
+  public static Version get() {
+    return currentVersion;
+  }
+
+  /**
+   * Returns the full version string for the currently loaded HBase library.
+   */
+  public static String getVersionString() {
+    return versionString;
+  }
+
+  /**
+   * Prints out the HBase {@link Version} enum value for the current version of HBase on the classpath.
+   */
+  public static void main(String[] args) {
+    Version version = HBaseVersion.get();
+    System.out.println(version.getMajorVersion());
+  }
+}

--- a/tephra-core/src/main/java/co/cask/tephra/util/HBaseVersionSpecificFactory.java
+++ b/tephra-core/src/main/java/co/cask/tephra/util/HBaseVersionSpecificFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.util;
+
+import com.google.inject.Provider;
+import com.google.inject.ProvisionException;
+import org.apache.twill.internal.utils.Instances;
+
+/**
+ * Common class factory behavior for classes which need specific implementations depending on HBase versions.
+ * Specific factories can subclass this class and simply plug in the class names for their implementations.
+ *
+ * @param <T> Version specific class provided by this factory.
+ */
+public abstract class HBaseVersionSpecificFactory<T> implements Provider<T> {
+  @Override
+  public T get() {
+    T instance = null;
+    try {
+      switch (HBaseVersion.get()) {
+        case HBASE_94:
+          instance = createInstance(getHBase94Classname());
+          break;
+        case HBASE_96:
+          instance = createInstance(getHBase96Classname());
+          break;
+        case HBASE_98:
+          instance = createInstance(getHBase98Classname());
+          break;
+        case UNKNOWN:
+          throw new ProvisionException("Unknown HBase version: " + HBaseVersion.getVersionString());
+      }
+    } catch (ClassNotFoundException cnfe) {
+      throw new ProvisionException(cnfe.getMessage(), cnfe);
+    }
+    return instance;
+  }
+
+  protected T createInstance(String className) throws ClassNotFoundException {
+    Class clz = Class.forName(className);
+    return (T) Instances.newInstance(clz);
+  }
+
+  protected abstract String getHBase94Classname();
+  protected abstract String getHBase96Classname();
+  protected abstract String getHBase98Classname();
+}

--- a/tephra-core/src/test/java/co/cask/tephra/TransactionContextTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/TransactionContextTest.java
@@ -30,7 +30,6 @@ import com.google.inject.Injector;
 import com.google.inject.Singleton;
 import com.google.inject.util.Modules;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -54,7 +53,7 @@ public class TransactionContextTest {
 
   @BeforeClass
   public static void setup() throws IOException {
-    final Configuration conf = HBaseConfiguration.create();
+    final Configuration conf = new Configuration();
     conf.set(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES, DefaultSnapshotCodec.class.getName());
     conf.set(TxConstants.Manager.CFG_TX_SNAPSHOT_DIR, tmpFolder.newFolder().getAbsolutePath());
     Injector injector = Guice.createInjector(

--- a/tephra-core/src/test/java/co/cask/tephra/TransactionExecutorTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/TransactionExecutorTest.java
@@ -30,7 +30,6 @@ import com.google.inject.Injector;
 import com.google.inject.Singleton;
 import com.google.inject.util.Modules;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -55,7 +54,7 @@ public class TransactionExecutorTest {
 
   @BeforeClass
   public static void setup() throws IOException {
-    final Configuration conf = HBaseConfiguration.create();
+    final Configuration conf = new Configuration();
     conf.set(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES, DefaultSnapshotCodec.class.getName());
     conf.set(TxConstants.Manager.CFG_TX_SNAPSHOT_DIR, tmpFolder.newFolder().getAbsolutePath());
     Injector injector = Guice.createInjector(

--- a/tephra-core/src/test/java/co/cask/tephra/TransactionManagerTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/TransactionManagerTest.java
@@ -21,7 +21,6 @@ import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.InMemoryTransactionStateStorage;
 import co.cask.tephra.persist.TransactionStateStorage;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -35,7 +34,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class TransactionManagerTest extends TransactionSystemTest {
 
-  static Configuration conf = HBaseConfiguration.create();
+  static Configuration conf = new Configuration();
 
   TransactionManager txManager = null;
   TransactionStateStorage txStateStorage = null;

--- a/tephra-core/src/test/java/co/cask/tephra/TransactionServiceMainTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/TransactionServiceMainTest.java
@@ -19,7 +19,6 @@ package co.cask.tephra;
 import co.cask.tephra.distributed.TransactionServiceClient;
 import com.google.common.base.Throwables;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.twill.internal.zookeeper.InMemoryZKServer;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -42,7 +41,7 @@ public class TransactionServiceMainTest {
     zkServer.startAndWait();
 
     try {
-      Configuration conf = HBaseConfiguration.create();
+      Configuration conf = new Configuration();
       conf.set(TxConstants.Service.CFG_DATA_TX_ZOOKEEPER_QUORUM, zkServer.getConnectionStr());
       conf.set(TxConstants.Manager.CFG_TX_SNAPSHOT_DIR, tmpFolder.newFolder().getAbsolutePath());
 

--- a/tephra-core/src/test/java/co/cask/tephra/TransactionSystemTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/TransactionSystemTest.java
@@ -18,7 +18,6 @@ package co.cask.tephra;
 
 import co.cask.tephra.persist.TransactionSnapshot;
 import co.cask.tephra.persist.TransactionStateStorage;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,10 +29,10 @@ import java.util.Collection;
  */
 public abstract class TransactionSystemTest {
 
-  public static final byte[] C1 = Bytes.toBytes("change1");
-  public static final byte[] C2 = Bytes.toBytes("change2");
-  public static final byte[] C3 = Bytes.toBytes("change3");
-  public static final byte[] C4 = Bytes.toBytes("change4");
+  public static final byte[] C1 = new byte[] { 'c', '1' };
+  public static final byte[] C2 = new byte[] { 'c', '2' };
+  public static final byte[] C3 = new byte[] { 'c', '3' };
+  public static final byte[] C4 = new byte[] { 'c', '4' };
 
   protected abstract TransactionSystemClient getClient() throws Exception;
 

--- a/tephra-core/src/test/java/co/cask/tephra/hbase/AbstractTransactionVisibilityFilterTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/hbase/AbstractTransactionVisibilityFilterTest.java
@@ -16,36 +16,32 @@
 
 package co.cask.tephra.hbase;
 
-import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TxConstants;
+import co.cask.tephra.util.ConfigurationFactory;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.filter.Filter;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.After;
 import org.junit.Before;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Common test class for TransactionVisibilityFilter implementations.
  */
 public abstract class AbstractTransactionVisibilityFilterTest {
 
-  protected static final byte[] FAM = Bytes.toBytes("f");
-  protected static final byte[] FAM2 = Bytes.toBytes("f2");
-  protected static final byte[] FAM3 = Bytes.toBytes("f3");
-  protected static final byte[] COL = Bytes.toBytes("c");
+  protected static final byte[] FAM = new byte[] {'f'};
+  protected static final byte[] FAM2 = new byte[] {'f', '2'};
+  protected static final byte[] FAM3 = new byte[] {'f', '3'};
+  protected static final byte[] COL = new byte[] {'c'};
   protected static final List<byte[]> EMPTY_CHANGESET = Lists.newArrayListWithCapacity(0);
 
   protected TransactionManager txManager;
 
   @Before
   public void setup() throws Exception {
-    Configuration conf = HBaseConfiguration.create();
+    Configuration conf = new ConfigurationFactory().get();
     conf.unset(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES);
     txManager = new TransactionManager(conf);
     txManager.startAndWait();
@@ -55,9 +51,4 @@ public abstract class AbstractTransactionVisibilityFilterTest {
   public void tearDown() throws Exception {
     txManager.stopAndWait();
   }
-
-  /**
-   * Creates a new TransactionVisibilityFilter for the specific HBase version of the implementation.
-   */
-  protected abstract Filter createFilter(Transaction tx, Map<byte[], Long> familyTTLs);
 }

--- a/tephra-core/src/test/java/co/cask/tephra/persist/HDFSTransactionStateStorageTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/HDFSTransactionStateStorageTest.java
@@ -20,7 +20,6 @@ import co.cask.tephra.TxConstants;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
 import co.cask.tephra.snapshot.SnapshotCodecV2;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -48,7 +47,7 @@ public class HDFSTransactionStateStorageTest extends AbstractTransactionStateSto
     hConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, tmpFolder.newFolder().getAbsolutePath());
 
     dfsCluster = new MiniDFSCluster.Builder(hConf).numDataNodes(1).build();
-    conf = HBaseConfiguration.create(dfsCluster.getFileSystem().getConf());
+    conf = new Configuration(dfsCluster.getFileSystem().getConf());
   }
 
   @AfterClass

--- a/tephra-core/src/test/java/co/cask/tephra/persist/LocalTransactionStateStorageTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/LocalTransactionStateStorageTest.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -55,7 +54,7 @@ public class LocalTransactionStateStorageTest extends AbstractTransactionStateSt
   @Override
   protected Configuration getConfiguration(String testName) throws IOException {
     File testDir = tmpDir.newFolder(testName);
-    Configuration conf = HBaseConfiguration.create();
+    Configuration conf = new Configuration();
     conf.set(TxConstants.Manager.CFG_TX_SNAPSHOT_LOCAL_DIR, testDir.getAbsolutePath());
     conf.set(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES, SnapshotCodecV2.class.getName());
 

--- a/tephra-core/src/test/java/co/cask/tephra/persist/TransactionEditTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/TransactionEditTest.java
@@ -20,7 +20,6 @@ import co.cask.tephra.ChangeId;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,6 +30,8 @@ import java.io.IOException;
  * test for {@link TransactionEdit}
  */
 public class TransactionEditTest {
+  private static final byte[] COL = new byte[] {'c'};
+
   @Test
   public void testV1SerdeCompat() throws Exception {
     TransactionEdit.TransactionEditCodec olderCodec = new TransactionEdit.TransactionEditCodecV1();
@@ -39,7 +40,7 @@ public class TransactionEditTest {
     // for decoding older versions that doesn't store it
     verifyDecodingSupportsOlderVersion(TransactionEdit.createStarted(2L, 0L, 1000L, null), olderCodec);
     verifyDecodingSupportsOlderVersion(
-      TransactionEdit.createCommitted(2L, Sets.newHashSet(new ChangeId(Bytes.toBytes("c"))), 3L, true), olderCodec);
+      TransactionEdit.createCommitted(2L, Sets.newHashSet(new ChangeId(COL)), 3L, true), olderCodec);
   }
   
   @Test
@@ -49,7 +50,7 @@ public class TransactionEditTest {
     // NOTE: transaction type to null as this is expected default for decoding older versions that doesn't store it
     verifyDecodingSupportsOlderVersion(TransactionEdit.createStarted(2L, 100L, 1000L, null), olderCodec);
     verifyDecodingSupportsOlderVersion(
-      TransactionEdit.createCommitted(2L, Sets.newHashSet(new ChangeId(Bytes.toBytes("c"))), 3L, true), olderCodec);
+      TransactionEdit.createCommitted(2L, Sets.newHashSet(new ChangeId(COL)), 3L, true), olderCodec);
   }
 
   @SuppressWarnings("deprecation")

--- a/tephra-core/src/test/java/co/cask/tephra/util/AbstractConfigurationProviderTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/util/AbstractConfigurationProviderTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.util;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ *
+ */
+public abstract class AbstractConfigurationProviderTest {
+  @Test
+  public void testVersionFactory() {
+    HBaseVersion.Version foundVersion = HBaseVersion.get();
+    assertEquals(getExpectedVersion(), foundVersion);
+  }
+
+  protected abstract HBaseVersion.Version getExpectedVersion();
+
+  @Test
+  public void testConfigurationProvider() {
+    Configuration conf = new Configuration();
+    conf.set("foo", "bar");
+    Configuration newConf = new ConfigurationFactory().get(conf);
+    assertNotNull(newConf);
+    assertEquals("bar", newConf.get("foo"));
+  }
+}

--- a/tephra-hbase-compat-0.94/src/main/java/co/cask/tephra/hbase94/HBase94ConfigurationProvider.java
+++ b/tephra-hbase-compat-0.94/src/main/java/co/cask/tephra/hbase94/HBase94ConfigurationProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.hbase94;
+
+import co.cask.tephra.util.ConfigurationProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+
+/**
+ * HBase 0.94 version of {@link co.cask.tephra.util.ConfigurationProvider}.
+ */
+public class HBase94ConfigurationProvider extends ConfigurationProvider {
+  @Override
+  public Configuration get() {
+    return HBaseConfiguration.create();
+  }
+
+  @Override
+  public Configuration get(Configuration baseConf) {
+    return HBaseConfiguration.create(baseConf);
+  }
+}

--- a/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/HBase94ConfigurationProviderTest.java
+++ b/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/HBase94ConfigurationProviderTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.hbase94;
+
+import co.cask.tephra.util.AbstractConfigurationProviderTest;
+import co.cask.tephra.util.HBaseVersion;
+
+/**
+ * Test for HBase 0.94 version specific behavior.
+ */
+public class HBase94ConfigurationProviderTest extends AbstractConfigurationProviderTest {
+  @Override
+  protected HBaseVersion.Version getExpectedVersion() {
+    return HBaseVersion.Version.HBASE_94;
+  }
+}

--- a/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/coprocessor/TransactionVisibilityFilterTest.java
@@ -124,7 +124,6 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
                  filter.filterKeyValue(newKeyValue("row2", FAM, "val1", now - 1 * TxConstants.MAX_TX_PER_MS)));
   }
 
-  @Override
   protected Filter createFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
     return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN);
   }

--- a/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/HBase96ConfigurationProvider.java
+++ b/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/HBase96ConfigurationProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.hbase96;
+
+import co.cask.tephra.util.ConfigurationProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+
+/**
+ * HBase 0.96 version of {@link co.cask.tephra.util.ConfigurationProvider}.
+ */
+public class HBase96ConfigurationProvider extends ConfigurationProvider {
+  @Override
+  public Configuration get() {
+    return HBaseConfiguration.create();
+  }
+
+  @Override
+  public Configuration get(Configuration baseConf) {
+    return HBaseConfiguration.create(baseConf);
+  }
+}

--- a/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/HBase96ConfigurationProviderTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/HBase96ConfigurationProviderTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.hbase96;
+
+import co.cask.tephra.util.AbstractConfigurationProviderTest;
+import co.cask.tephra.util.HBaseVersion;
+
+/**
+ * Test for HBase 0.96 version specific behavior.
+ */
+public class HBase96ConfigurationProviderTest extends AbstractConfigurationProviderTest {
+  @Override
+  protected HBaseVersion.Version getExpectedVersion() {
+    return HBaseVersion.Version.HBASE_96;
+  }
+}

--- a/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/coprocessor/TransactionVisibilityFilterTest.java
@@ -124,7 +124,6 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
                  filter.filterKeyValue(newKeyValue("row2", FAM, "val1", now - 1 * TxConstants.MAX_TX_PER_MS)));
   }
 
-  @Override
   protected Filter createFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
     return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN);
   }

--- a/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/HBase98ConfigurationProvider.java
+++ b/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/HBase98ConfigurationProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.hbase98;
+
+import co.cask.tephra.util.ConfigurationProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+
+/**
+ * HBase 0.98 version of {@link co.cask.tephra.util.ConfigurationProvider}.
+ */
+public class HBase98ConfigurationProvider extends ConfigurationProvider {
+  @Override
+  public Configuration get() {
+    return HBaseConfiguration.create();
+  }
+
+  @Override
+  public Configuration get(Configuration baseConf) {
+    return HBaseConfiguration.create(baseConf);
+  }
+}

--- a/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/HBase98ConfigurationProviderTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/HBase98ConfigurationProviderTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.hbase98;
+
+import co.cask.tephra.util.AbstractConfigurationProviderTest;
+import co.cask.tephra.util.HBaseVersion;
+
+/**
+ * Test for HBase 0.98 version specific behavior.
+ */
+public class HBase98ConfigurationProviderTest extends AbstractConfigurationProviderTest {
+  @Override
+  protected HBaseVersion.Version getExpectedVersion() {
+    return HBaseVersion.Version.HBASE_98;
+  }
+}

--- a/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/coprocessor/TransactionVisibilityFilterTest.java
@@ -124,7 +124,6 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
                  filter.filterKeyValue(newKeyValue("row2", FAM, "val1", now - 1 * TxConstants.MAX_TX_PER_MS)));
   }
 
-  @Override
   protected Filter createFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
     return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN);
   }


### PR DESCRIPTION
Removes all remaining usage of HBase classes in the tephra-core module.