### PR TITLE
TEPHRA-82 Minimize change set retained by client for row-level conflict detection

### DIFF
--- a/tephra-core/src/main/java/co/cask/tephra/AbstractTransactionAwareTable.java
+++ b/tephra-core/src/main/java/co/cask/tephra/AbstractTransactionAwareTable.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Objects;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Base class for all the common parts of the HBase version-specific {@code TransactionAwareHTable}
+ * implementations.
+ */
+public abstract class AbstractTransactionAwareTable implements TransactionAware {
+  protected final TransactionCodec txCodec;
+  protected final Set<ActionChange> changeSet;
+  protected final TxConstants.ConflictDetection conflictLevel;
+  protected Transaction tx;
+  protected boolean allowNonTransactional;
+
+  public AbstractTransactionAwareTable(TxConstants.ConflictDetection conflictLevel, boolean allowNonTransactional) {
+    this.conflictLevel = conflictLevel;
+    this.allowNonTransactional = allowNonTransactional;
+    this.txCodec = new TransactionCodec();
+    this.changeSet = new HashSet<ActionChange>();
+  }
+
+  /**
+   * True if the instance allows non-transaction operations.
+   * @return
+   */
+  public boolean getAllowNonTransactional() {
+    return this.allowNonTransactional;
+  }
+
+  /**
+   * Set whether the instance allows non-transactional operations.
+   * @param allowNonTransactional
+   */
+  public void setAllowNonTransactional(boolean allowNonTransactional) {
+    this.allowNonTransactional = allowNonTransactional;
+  }
+
+  @Override
+  public void startTx(Transaction tx) {
+    this.tx = tx;
+  }
+
+  @Override
+  public Collection<byte[]> getTxChanges() {
+    Collection<byte[]> txChanges = new TreeSet<byte[]>(UnsignedBytes.lexicographicalComparator());
+    for (ActionChange change : changeSet) {
+      txChanges.add(getChangeKey(change.getRow(), change.getFamily(), change.getQualifier()));
+    }
+    return txChanges;
+  }
+
+  public byte[] getChangeKey(byte[] row, byte[] family, byte[] qualifier) {
+    byte[] key;
+    switch (conflictLevel) {
+      case ROW:
+        key = Bytes.concat(getTableKey(), row);
+        break;
+      case COLUMN:
+        key = Bytes.concat(getTableKey(), row, family, qualifier);
+        break;
+      default:
+        throw new IllegalStateException("Unknown conflict detection level: " + conflictLevel);
+    }
+    return key;
+  }
+
+  @Override
+  public boolean commitTx() throws Exception {
+    return doCommit();
+  }
+
+  /**
+   * Commits any pending writes by flushing the wrapped {@code HTable} instance.
+   */
+  protected abstract boolean doCommit() throws IOException;
+
+  @Override
+  public void postTxCommit() {
+    tx = null;
+    changeSet.clear();
+  }
+
+  @Override
+  public String getTransactionAwareName() {
+    return new String(getTableKey(), Charsets.UTF_8);
+  }
+
+  /**
+   * Returns the table name to use as a key prefix for the transaction change set.
+   */
+  protected abstract byte[] getTableKey();
+
+  @Override
+  public boolean rollbackTx() throws Exception {
+    return doRollback();
+  }
+
+  /**
+   * Rolls back any persisted changes from the transaction by issuing offsetting deletes to the
+   * wrapped {@code HTable} instance.  How this is handled will depend on the delete API exposed
+   * by the specific version of HBase.
+   */
+  protected abstract boolean doRollback() throws Exception;
+
+  protected void addToChangeSet(byte[] row, byte[] family, byte[] qualifier) {
+    switch (conflictLevel) {
+      case ROW:
+        // even with row-level conflict detection, we need to track changes per-family, since this
+        // is the granularity at which we will issue deletes for rollback
+        changeSet.add(new ActionChange(row, family));
+        break;
+      case COLUMN:
+        changeSet.add(new ActionChange(row, family, qualifier));
+        break;
+      default:
+        throw new IllegalStateException("Unknown conflict detection level: " + conflictLevel);
+    }
+  }
+
+  /**
+   * Record of each transaction that causes a change. This reference is used to rollback
+   * any operation upon failure.
+   */
+  protected class ActionChange {
+    private final byte[] row;
+    private final byte[] family;
+    private final byte[] qualifier;
+
+    public ActionChange(byte[] row, byte[] family) {
+      this(row, family, null);
+    }
+
+    public ActionChange(byte[] row, byte[] family, byte[] qualifier) {
+      this.row = row;
+      this.family = family;
+      this.qualifier = qualifier;
+    }
+
+    public byte[] getRow() {
+      return row;
+    }
+
+    public byte[] getFamily() {
+      return family;
+    }
+
+    public byte[] getQualifier() {
+      return qualifier;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || o.getClass() != this.getClass()) {
+        return false;
+      }
+
+      if (o == this) {
+        return true;
+      }
+
+      ActionChange other = (ActionChange) o;
+      return Objects.equal(this.row, other.row) &&
+             Objects.equal(this.family, other.family) &&
+             Objects.equal(this.qualifier, other.qualifier);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Arrays.hashCode(row);
+      result = 31 * result + (family != null ? Arrays.hashCode(family) : 0);
+      result = 31 * result + (qualifier != null ? Arrays.hashCode(qualifier) : 0);
+      return result;
+    }
+  }
+}

--- a/tephra-hbase-compat-0.94/src/main/java/co/cask/tephra/hbase94/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-0.94/src/main/java/co/cask/tephra/hbase94/TransactionAwareHTable.java
@@ -15,9 +15,9 @@
 */
 package co.cask.tephra.hbase94;
 
+import co.cask.tephra.AbstractTransactionAwareTable;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
-import co.cask.tephra.TransactionCodec;
 import co.cask.tephra.TxConstants;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -38,30 +38,24 @@ import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.coprocessor.Batch;
 import org.apache.hadoop.hbase.ipc.CoprocessorProtocol;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
-import java.util.TreeSet;
 
 /**
 * A Transaction Aware HTable implementation for HBase 0.94.
 */
-public class TransactionAwareHTable implements HTableInterface, TransactionAware {
+public class TransactionAwareHTable extends AbstractTransactionAwareTable
+    implements HTableInterface, TransactionAware {
+
   private static final Logger LOG = LoggerFactory.getLogger(TransactionAwareHTable.class);
-  private Transaction tx;
   private final HTableInterface hTable;
-  private final TransactionCodec txCodec;
-  private final List<ActionChange> changeSet;
-  private final TxConstants.ConflictDetection conflictLevel;
-  private boolean allowNonTransactional;
 
   /**
    * Create a transactional aware instance of the passed HTable
@@ -76,7 +70,7 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
    * Create a transactional aware instance of the passed HTable
    *
    * @param hTable underlying HBase table to use
-   * @param conflictLevel level of conflict detection to perform
+   * @param conflictLevel level of conflict detection to perform (defaults to {@code COLUMN})
    */
   public TransactionAwareHTable(HTableInterface hTable, TxConstants.ConflictDetection conflictLevel) {
     this(hTable, conflictLevel, false);
@@ -97,34 +91,70 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
    * Create a transactional aware instance of the passed HTable, with the option
    * of allowing non-transactional operations.
    * @param hTable underlying HBase table to use
-   * @param conflictLevel level of conflict detection to perform
+   * @param conflictLevel level of conflict detection to perform (defaults to {@code COLUMN})
    * @param allowNonTransactional if true, additional operations (checkAndPut, increment, checkAndDelete)
    *                              will be available, though non-transactional
    */
   public TransactionAwareHTable(HTableInterface hTable, TxConstants.ConflictDetection conflictLevel,
                                 boolean allowNonTransactional) {
+    super(conflictLevel, allowNonTransactional);
     this.hTable = hTable;
-    this.changeSet = new ArrayList<ActionChange>();
-    this.txCodec = new TransactionCodec();
-    this.allowNonTransactional = allowNonTransactional;
-    this.conflictLevel = conflictLevel;
   }
 
-  /**
-   * True if the instance allows non-transaction operations.
-   * @return
-   */
-  public boolean getAllowNonTransactional() {
-    return this.allowNonTransactional;
+  /* AbstractTransactionAwareTable implementation */
+
+  @Override
+  protected byte[] getTableKey() {
+    return getTableName();
   }
 
-  /**
-   * Set whether the instance allows non-transactional operations.
-   * @param allowNonTransactional
-   */
-  public void setAllowNonTransactional(boolean allowNonTransactional) {
-    this.allowNonTransactional = allowNonTransactional;
+  @Override
+  protected boolean doCommit() throws IOException {
+    hTable.flushCommits();
+    return true;
   }
+
+  @Override
+  protected boolean doRollback() throws Exception {
+    try {
+      List<Delete> rollbackDeletes = new ArrayList<Delete>(changeSet.size());
+      for (ActionChange change : changeSet) {
+        byte[] row = change.getRow();
+        byte[] family = change.getFamily();
+        byte[] qualifier = change.getQualifier();
+        long transactionTimestamp = tx.getWritePointer();
+        Delete rollbackDelete = new Delete(row, transactionTimestamp);
+        if (family != null && qualifier == null) {
+          rollbackDelete.deleteFamily(family, transactionTimestamp);
+        } else if (family != null && qualifier != null) {
+          rollbackDelete.deleteColumn(family, qualifier, transactionTimestamp);
+        }
+        rollbackDeletes.add(rollbackDelete);
+      }
+      hTable.delete(rollbackDeletes);
+      return true;
+    } finally {
+      try {
+        hTable.flushCommits();
+      } catch (Exception e) {
+        LOG.error("Could not flush HTable commits", e);
+      }
+      tx = null;
+      changeSet.clear();
+    }
+  }
+
+  @Override
+  protected void addToChangeSet(byte[] row, byte[] family, byte[] qualifier) {
+    // HBase 0.94 only supports deletes of a specific version at the column-level.
+    // Since we rely on version deletes to rollback a failed transaction, we must
+    // keep full column-level information in the change set we store, regardless of the
+    // configured conflict detection level.
+    changeSet.add(new ActionChange(row, family, qualifier));
+  }
+
+
+  /* HTableInterface implementation */
 
   @Override
   public byte[] getTableName() {
@@ -377,7 +407,7 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
   @Override
   public <T extends CoprocessorProtocol, R> void coprocessorExec(Class<T> protocol, byte[] startKey, byte[] endKey,
                                                                  Batch.Call<T, R> callable, Batch.Callback<R> callback)
-    throws IOException, Throwable {
+  throws IOException, Throwable {
     hTable.coprocessorExec(protocol, startKey, endKey, callable, callback);
   }
 
@@ -401,82 +431,6 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
     hTable.setWriteBufferSize(writeBufferSize);
   }
 
-  @Override
-  public void startTx(Transaction tx) {
-    this.tx = tx;
-  }
-
-  @Override
-  public Collection<byte[]> getTxChanges() {
-    Collection<byte[]> txChanges;
-    switch (conflictLevel) {
-      case ROW:
-        // avoid reporting duplicate row keys
-        txChanges = new TreeSet<byte[]>(Bytes.BYTES_COMPARATOR);
-        for (ActionChange change : changeSet) {
-          txChanges.add(Bytes.add(getTableName(), change.getRow()));
-        }
-        break;
-      case COLUMN:
-        txChanges = new ArrayList<byte[]>(changeSet.size());
-        for (ActionChange change : changeSet) {
-          txChanges.add(Bytes.add(getTableName(), change.getRow(),
-              Bytes.add(change.getFamily(), change.getQualifier())));
-        }
-        break;
-      default:
-        throw new IllegalStateException("Unknown conflict detection level: " + conflictLevel);
-    }
-    return txChanges;
-  }
-
-  @Override
-  public boolean commitTx() throws Exception {
-    hTable.flushCommits();
-    return true;
-  }
-
-  @Override
-  public void postTxCommit() {
-    tx = null;
-    changeSet.clear();
-  }
-
-  @Override
-  public boolean rollbackTx() throws Exception {
-    try {
-      List<Delete> rollbackDeletes = new ArrayList<Delete>(changeSet.size());
-      for (ActionChange change : changeSet) {
-        byte[] row = change.getRow();
-        byte[] family = change.getFamily();
-        byte[] qualifier = change.getQualifier();
-        long transactionTimestamp = tx.getWritePointer();
-        Delete rollbackDelete = new Delete(row, transactionTimestamp);
-        if (family != null && qualifier == null) {
-          rollbackDelete.deleteFamily(family, transactionTimestamp);
-        } else if (family != null && qualifier != null) {
-          rollbackDelete.deleteColumn(family, qualifier, transactionTimestamp);
-        }
-        rollbackDeletes.add(rollbackDelete);
-      }
-      hTable.delete(rollbackDeletes);
-      return true;
-    } finally {
-      try {
-        hTable.flushCommits();
-      } catch (Exception e) {
-        LOG.error("Could not flush HTable commits", e);
-      }
-      tx = null;
-      changeSet.clear();
-    }
-  }
-
-  @Override
-  public String getTransactionAwareName() {
-    return Bytes.toString(getTableName());
-  }
-
   // Helpers to get copies of objects with the timestamp set to the current transaction timestamp.
 
   private Get transactionalizeAction(Get get) throws IOException {
@@ -489,34 +443,6 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
     return scan;
   }
 
-  /**
-   * Record of each transaction that causes a change. This reference is used to rollback
-   * any operation upon failure.
-   */
-  private class ActionChange {
-    private final byte[] row;
-    private final byte[] family;
-    private final byte[] qualifier;
-
-    private ActionChange(byte[] row, byte[] family, byte[] qualifier) {
-      this.row = row;
-      this.family = family;
-      this.qualifier = qualifier;
-    }
-
-    private byte[] getRow() {
-      return row;
-    }
-
-    private byte[] getFamily() {
-      return family;
-    }
-
-    private byte[] getQualifier() {
-      return qualifier;
-    }
-  }
-
   private Put transactionalizeAction(Put put) throws IOException {
     Put txPut = new Put(put.getRow(), tx.getWritePointer());
     Set<Map.Entry<byte[], List<KeyValue>>> familyMap = put.getFamilyMap().entrySet();
@@ -526,7 +452,7 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
         if (!familyValues.isEmpty()) {
           for (KeyValue value : familyValues) {
             txPut.add(value.getFamily(), value.getQualifier(), tx.getWritePointer(), value.getValue());
-            changeSet.add(new ActionChange(txPut.getRow(), value.getFamily(), value.getQualifier()));
+            addToChangeSet(txPut.getRow(), value.getFamily(), value.getQualifier());
           }
         }
       }
@@ -554,7 +480,7 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
         NavigableMap<byte[], byte[]> familyColumns = result.getFamilyMap(familyEntry.getKey());
         for (Map.Entry<byte[], byte[]> column : familyColumns.entrySet()) {
           txPut.add(familyEntry.getKey(), column.getKey(), transactionTimestamp, new byte[0]);
-          changeSet.add(new ActionChange(deleteRow, familyEntry.getKey(), column.getKey()));
+          addToChangeSet(deleteRow, familyEntry.getKey(), column.getKey());
         }
       }
     } else {
@@ -567,12 +493,12 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
           NavigableMap<byte[], byte[]> familyColumns = result.getFamilyMap(family);
           for (Map.Entry<byte[], byte[]> column : familyColumns.entrySet()) {
             txPut.add(family, column.getKey(), transactionTimestamp, new byte[0]);
-            changeSet.add(new ActionChange(deleteRow, family, column.getKey()));
+            addToChangeSet(deleteRow, family, column.getKey());
           }
         } else {
           for (KeyValue value : entries) {
             txPut.add(value.getFamily(), value.getQualifier(), transactionTimestamp, new byte[0]);
-            changeSet.add(new ActionChange(deleteRow, value.getFamily(), value.getQualifier()));
+            addToChangeSet(deleteRow, value.getFamily(), value.getQualifier());
           }
         }
       }

--- a/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/TransactionAwareHTableTest.java
@@ -44,11 +44,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -380,5 +383,17 @@ public class TransactionAwareHTableTest {
     // should now be val1
     assertArrayEquals(val1, cell.getValue());
     transactionContext.finish();
+
+    // verify change set that is being reported only on rows
+    txContext1.start();
+    txTable1.put(new Put(row1).add(TestBytes.family, col1, val1));
+    txTable1.put(new Put(row2).add(TestBytes.family, col2, val2));
+
+    Collection<byte[]> changeSet = txTable1.getTxChanges();
+    assertNotNull(changeSet);
+    assertEquals(2, changeSet.size());
+    assertTrue(changeSet.contains(txTable1.getChangeKey(row1, null, null)));
+    assertTrue(changeSet.contains(txTable1.getChangeKey(row2, null, null)));
+    txContext1.finish();
   }
 }

--- a/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/TransactionAwareHTable.java
@@ -15,9 +15,9 @@
  */
 package co.cask.tephra.hbase96;
 
+import co.cask.tephra.AbstractTransactionAwareTable;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
-import co.cask.tephra.TransactionCodec;
 import co.cask.tephra.TxConstants;
 import com.google.protobuf.Service;
 import com.google.protobuf.ServiceException;
@@ -41,32 +41,26 @@ import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.coprocessor.Batch;
 import org.apache.hadoop.hbase.ipc.CoprocessorRpcChannel;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * A Transaction Aware HTable implementation for HBase 0.96. Operations are committed as usual,
  * but upon a failed or aborted transaction, they are rolled back to the state before the transaction
  * was started.
  */
-public class TransactionAwareHTable implements HTableInterface, TransactionAware {
+public class TransactionAwareHTable extends AbstractTransactionAwareTable
+    implements HTableInterface, TransactionAware {
+
   private static final Logger LOG = LoggerFactory.getLogger(TransactionAwareHTable.class);
-  private Transaction tx;
   private final HTableInterface hTable;
-  private final TransactionCodec txCodec;
-  private final List<ActionChange> changeSet;
-  private final TxConstants.ConflictDetection conflictLevel;
-  private boolean allowNonTransactional;
 
   /**
    * Create a transactional aware instance of the passed HTable
@@ -81,7 +75,7 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
    * Create a transactional aware instance of the passed HTable
    *
    * @param hTable underlying HBase table to use
-   * @param conflictLevel level of conflict detection to perform
+   * @param conflictLevel level of conflict detection to perform (defaults to {@code COLUMN})
    */
   public TransactionAwareHTable(HTableInterface hTable, TxConstants.ConflictDetection conflictLevel) {
     this(hTable, conflictLevel, false);
@@ -102,34 +96,70 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
    * Create a transactional aware instance of the passed HTable, with the option
    * of allowing non-transactional operations.
    * @param hTable underlying HBase table to use
-   * @param conflictLevel level of conflict detection to perform
+   * @param conflictLevel level of conflict detection to perform (defaults to {@code COLUMN})
    * @param allowNonTransactional if true, additional operations (checkAndPut, increment, checkAndDelete)
    *                              will be available, though non-transactional
    */
   public TransactionAwareHTable(HTableInterface hTable, TxConstants.ConflictDetection conflictLevel,
                                 boolean allowNonTransactional) {
+    super(conflictLevel, allowNonTransactional);
     this.hTable = hTable;
-    this.changeSet = new ArrayList<ActionChange>();
-    this.txCodec = new TransactionCodec();
-    this.allowNonTransactional = allowNonTransactional;
-    this.conflictLevel = conflictLevel;
   }
 
-  /**
-   * True if the instance allows non-transaction operations.
-   * @return
-   */
-  public boolean getAllowNonTransactional() {
-    return this.allowNonTransactional;
+  /* AbstractTransactionAwareTable implementation */
+
+  @Override
+  protected byte[] getTableKey() {
+    return getTableName();
   }
 
-  /**
-   * Set whether the instance allows non-transactional operations.
-   * @param allowNonTransactional
-   */
-  public void setAllowNonTransactional(boolean allowNonTransactional) {
-    this.allowNonTransactional = allowNonTransactional;
+  @Override
+  protected boolean doCommit() throws IOException {
+    hTable.flushCommits();
+    return true;
   }
+
+  @Override
+  protected boolean doRollback() throws Exception {
+    try {
+      List<Delete> rollbackDeletes = new ArrayList<Delete>(changeSet.size());
+      for (ActionChange change : changeSet) {
+        byte[] row = change.getRow();
+        byte[] family = change.getFamily();
+        byte[] qualifier = change.getQualifier();
+        long transactionTimestamp = tx.getWritePointer();
+        Delete rollbackDelete = new Delete(row);
+        switch (conflictLevel) {
+          case ROW:
+            // issue family delete for the tx write pointer
+            rollbackDelete.deleteFamilyVersion(change.getFamily(), transactionTimestamp);
+            break;
+          case COLUMN:
+            if (family != null && qualifier == null) {
+              rollbackDelete.deleteFamilyVersion(family, transactionTimestamp);
+            } else if (family != null && qualifier != null) {
+              rollbackDelete.deleteColumn(family, qualifier, transactionTimestamp);
+            }
+            break;
+          default:
+            throw new IllegalStateException("Unknown conflict detection level: " + conflictLevel);
+        }
+        rollbackDeletes.add(rollbackDelete);
+      }
+      hTable.delete(rollbackDeletes);
+      return true;
+    } finally {
+      try {
+        hTable.flushCommits();
+      } catch (Exception e) {
+        LOG.error("Could not flush HTable commits", e);
+      }
+      tx = null;
+      changeSet.clear();
+    }
+  }
+
+  /* HTableInterface implementation */
 
   @Override
   public byte[] getTableName() {
@@ -446,110 +476,6 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
     hTable.setWriteBufferSize(writeBufferSize);
   }
 
-  @Override
-  public void startTx(Transaction tx) {
-    this.tx = tx;
-  }
-
-  @Override
-  public Collection<byte[]> getTxChanges() {
-    Collection<byte[]> txChanges;
-    switch (conflictLevel) {
-      case ROW:
-        // avoid reporting duplicate row keys
-        txChanges = new TreeSet<byte[]>(Bytes.BYTES_COMPARATOR);
-        for (ActionChange change : changeSet) {
-          txChanges.add(Bytes.add(getTableName(), change.getRow()));
-        }
-        break;
-      case COLUMN:
-        txChanges = new ArrayList<byte[]>(changeSet.size());
-        for (ActionChange change : changeSet) {
-          txChanges.add(Bytes.add(getTableName(), change.getRow(),
-              Bytes.add(change.getFamily(), change.getQualifier())));
-        }
-        break;
-      default:
-        throw new IllegalStateException("Unknown conflict detection level: " + conflictLevel);
-    }
-    return txChanges;
-  }
-
-  @Override
-  public boolean commitTx() throws Exception {
-    hTable.flushCommits();
-    return true;
-  }
-
-  @Override
-  public void postTxCommit() {
-    tx = null;
-    changeSet.clear();
-  }
-
-  @Override
-  public boolean rollbackTx() throws Exception {
-    try {
-      List<Delete> rollbackDeletes = new ArrayList<Delete>(changeSet.size());
-      for (ActionChange change : changeSet) {
-        byte[] row = change.getRow();
-        byte[] family = change.getFamily();
-        byte[] qualifier = change.getQualifier();
-        long transactionTimestamp = tx.getWritePointer();
-        Delete rollbackDelete = new Delete(row, transactionTimestamp);
-        if (family != null && qualifier == null) {
-          rollbackDelete.deleteFamily(family, transactionTimestamp);
-        } else if (family != null && qualifier != null) {
-          rollbackDelete.deleteColumn(family, qualifier, transactionTimestamp);
-        }
-        rollbackDeletes.add(rollbackDelete);
-      }
-      hTable.delete(rollbackDeletes);
-      return true;
-    } finally {
-      try {
-        hTable.flushCommits();
-      } catch (Exception e) {
-        LOG.error("Could not flush HTable commits", e);
-      }
-      tx = null;
-      changeSet.clear();
-    }
-  }
-
-  @Override
-  public String getTransactionAwareName() {
-    return Bytes.toString(getTableName());
-  }
-
-  /**
-   * Record of each transaction that causes a change. This reference is used to rollback
-   * any operation upon failure.
-   */
-  private class ActionChange {
-    private final byte[] row;
-    private final byte[] family;
-    private final byte[] qualifier;
-
-    private ActionChange(byte[] row, byte[] family, byte[] qualifier) {
-      this.row = row;
-      this.family = family;
-      this.qualifier = qualifier;
-    }
-
-    private byte[] getRow() {
-      return row;
-    }
-
-    private byte[] getFamily() {
-      return family;
-    }
-
-    private byte[] getQualifier() {
-      return qualifier;
-    }
-  }
-
   // Helpers to get copies of objects with the timestamp set to the current transaction timestamp.
 
   private Get transactionalizeAction(Get get) throws IOException {
@@ -571,7 +497,7 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
         if (!familyValues.isEmpty()) {
           for (KeyValue value : familyValues) {
             txPut.add(value.getFamily(), value.getQualifier(), tx.getWritePointer(), value.getValue());
-            changeSet.add(new ActionChange(txPut.getRow(), value.getFamily(), value.getQualifier()));
+            addToChangeSet(txPut.getRow(), value.getFamily(), value.getQualifier());
           }
         }
       }
@@ -599,7 +525,7 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
         NavigableMap<byte[], byte[]> familyColumns = result.getFamilyMap(familyEntry.getKey());
         for (Map.Entry<byte[], byte[]> column : familyColumns.entrySet()) {
           txPut.add(familyEntry.getKey(), column.getKey(), transactionTimestamp, new byte[0]);
-          changeSet.add(new ActionChange(deleteRow, familyEntry.getKey(), column.getKey()));
+          addToChangeSet(deleteRow, familyEntry.getKey(), column.getKey());
         }
       }
     } else {
@@ -612,12 +538,12 @@ public class TransactionAwareHTable implements HTableInterface, TransactionAware
           NavigableMap<byte[], byte[]> familyColumns = result.getFamilyMap(family);
           for (Map.Entry<byte[], byte[]> column : familyColumns.entrySet()) {
             txPut.add(family, column.getKey(), transactionTimestamp, new byte[0]);
-            changeSet.add(new ActionChange(deleteRow, family, column.getKey()));
+            addToChangeSet(deleteRow, family, column.getKey());
           }
         } else {
           for (KeyValue value : entries) {
             txPut.add(value.getFamily(), value.getQualifier(), transactionTimestamp, new byte[0]);
-            changeSet.add(new ActionChange(deleteRow, value.getFamily(), value.getQualifier()));
+            addToChangeSet(deleteRow, value.getFamily(), value.getQualifier());
           }
         }
       }

--- a/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/TransactionAwareHTableTest.java
@@ -46,11 +46,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -380,5 +383,17 @@ public class TransactionAwareHTableTest {
     // should now be val1
     assertArrayEquals(val1, CellUtil.cloneValue(cell));
     transactionContext.finish();
+
+    // verify change set that is being reported only on rows
+    txContext1.start();
+    txTable1.put(new Put(row1).add(TestBytes.family, col1, val1));
+    txTable1.put(new Put(row2).add(TestBytes.family, col2, val2));
+
+    Collection<byte[]> changeSet = txTable1.getTxChanges();
+    assertNotNull(changeSet);
+    assertEquals(2, changeSet.size());
+    assertTrue(changeSet.contains(txTable1.getChangeKey(row1, null, null)));
+    assertTrue(changeSet.contains(txTable1.getChangeKey(row2, null, null)));
+    txContext1.finish();
   }
 }


### PR DESCRIPTION
This patch minimizes the change set retained in memory by TransactionAwareHTable, where possible.  For HBase 0.94, we still need to retain the full row + family + qualifier for all write in the change set.  However in HBase 0.96+, the delete API now supports a version-specific column family delete.  This allows us to retain just the row + family in the change set when using row-level conflict detection.  In the case of transaction rollback, we simply issue version specific deletes for each row + family that was written.  This minimizes the change set we must retain in memory and reduces the number of delete operations we must issue for rollback, potentially by a large amount.