### PR TITLE
TEPHRA-73 Add a metrics collector implementation that does reporting via JMX and logging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,8 @@ properties can be added to the ``hbase-site.xml`` file on the server's ``CLASSPA
 +-------------------------------+------------+-----------------------------------------------------------------+
 | ``data.tx.snapshot.retain``   | 10         | Number of old transaction snapshots to retain                   |
 +-------------------------------+------------+-----------------------------------------------------------------+
+| ``data.tx.metrics.period``    | 60         | Frequency for metrics reporting (seconds)                       |
++-------------------------------+------------+-----------------------------------------------------------------+
 
 To run the Transaction server, execute the following command in your Tephra installation::
 
@@ -246,6 +248,40 @@ For HBase 0.98::
 You may configure the ``TransactionProcessor`` to be loaded only on HBase tables that you will
 be using for transaction reads and writes.  However, you must ensure that the coprocessor is 
 available on all impacted tables in order for Tephra to function correctly.
+
+Metrics Reporting
+.................
+
+Tephra ships with built-in support for reporting metrics via JMX and a log file, using the
+`Dropwizard Metrics <http://metrics.dropwizard.io>`_ library.
+
+To enable JMX reporting for metrics, you will need to enable JMX in the Java runtime
+arguments. Edit the ``bin/tephra-env.sh`` script and uncomment the following lines, making any
+desired changes to configuration for port used, SSL, and JMX authentication::
+
+  # export JMX_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=13001"
+  # export OPTS="$OPTS $JMX_OPTS"
+
+To enable file-based reporting for metrics, edit the ``conf/logback.xml`` file and uncomment the
+following section, replacing the ``FILE-PATH`` placeholder with a valid directory on the local
+filesystem::
+
+  <appender name="METRICS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>/FILE-PATH/metrics.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>metrics.log.%d{yyyy-MM-dd}</fileNamePattern>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{ISO8601} %msg%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="tephra-metrics" level="TRACE" additivity="false">
+    <appender-ref ref="METRICS" />
+  </logger>
+
+The frequency of metrics reporting may be configured by setting the ``data.tx.metrics.period``
+configuration property to the report frequency in seconds.
 
 
 Client APIs

--- a/bin/tephra-env.sh
+++ b/bin/tephra-env.sh
@@ -36,8 +36,20 @@ export PID_DIR=/tmp
 # Set the JVM heap size
 # export JAVA_HEAPMAX=-Xmx2048m
 
+# Additional runtime options
+#
+# GC logging options.
+# Uncomment the following two lines, making any desired changes, to enable GC logging output
+# export GC_LOG_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:server-gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=2 -XX:GCLogFileSize=50M"
+# export OPTS="$OPTS $GC_LOG_OPTS"
+#
+# JMX options.
+# Uncomment the following two lines, making any desired changes, to enable remote JMX connectivity
+# export JMX_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=13001"
+# export OPTS="$OPTS $JMX_OPTS"
+
 # Extra Java runtime options.
 # Below are what we set by default.  May only work with SUN JVM.
 # For more on why as well as other possible settings,
 # see http://wiki.apache.org/hadoop/PerformanceTuning
-export OPTS="-XX:+UseConcMarkSweepGC"
+export OPTS="$OPTS -XX:+UseConcMarkSweepGC"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<configuration>
+
+    <!--
+      Disabling some chatty loggers.
+    -->
+    <logger name="org.apache.commons.beanutils" level="ERROR"/>
+    <logger name="org.apache.zookeeper.server" level="ERROR"/>
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="com.ning" level="WARN"/>
+    <logger name="org.apache.hadoop" level="WARN"/>
+    <logger name="org.apache.hive" level="WARN"/>
+    <logger name="org.quartz.core" level="WARN"/>
+    <logger name="co.cask.tephra" level="INFO"/>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+        <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+      </encoder>
+    </appender>
+
+    <root level="ERROR">
+      <appender-ref ref="Console"/>
+    </root>
+
+    <!--
+      Uncomment the following section to enable metrics reporting to the given log file.
+      Replace the FILE-PATH placeholder with a valid path on the local filesystem.
+    -->
+    <!--
+    <appender name="METRICS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>/FILE-PATH/metrics.log</file>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <fileNamePattern>metrics.log.%d{yyyy-MM-dd}</fileNamePattern>
+        <maxHistory>30</maxHistory>
+      </rollingPolicy>
+      <encoder>
+        <pattern>%d{ISO8601} %msg%n</pattern>
+      </encoder>
+    </appender>
+    <logger name="tephra-metrics" level="TRACE" additivity="false">
+      <appender-ref ref="METRICS" />
+    </logger>
+    -->
+</configuration>
+

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
     <slf4j.version>1.7.5</slf4j.version>
     <thrift.version>0.9.0</thrift.version>
     <twill.version>0.4.0-incubating</twill.version>
+    <dropwizard.metrics.version>3.1.0</dropwizard.metrics.version>
   </properties>
 
   <dependencyManagement>
@@ -190,6 +191,11 @@
         <groupId>org.apache.twill</groupId>
         <artifactId>twill-zookeeper</artifactId>
         <version>${twill.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>${dropwizard.metrics.version}</version>
       </dependency>
 
       <!-- Hadoop dependencies -->

--- a/tephra-core/pom.xml
+++ b/tephra-core/pom.xml
@@ -90,6 +90,10 @@
       <artifactId>twill-zookeeper</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>

--- a/tephra-core/src/main/java/co/cask/tephra/TransactionManager.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TransactionManager.java
@@ -16,7 +16,8 @@
 
 package co.cask.tephra;
 
-import co.cask.tephra.metrics.TxMetricsCollector;
+import co.cask.tephra.metrics.DefaultMetricsCollector;
+import co.cask.tephra.metrics.MetricsCollector;
 import co.cask.tephra.persist.NoOpTransactionStateStorage;
 import co.cask.tephra.persist.TransactionEdit;
 import co.cask.tephra.persist.TransactionLog;
@@ -131,7 +132,7 @@ public class TransactionManager extends AbstractService {
 
   private long readPointer;
   private long lastWritePointer;
-  private TxMetricsCollector txMetricsCollector;
+  private MetricsCollector txMetricsCollector;
 
   private final TransactionStateStorage persistor;
 
@@ -158,12 +159,12 @@ public class TransactionManager extends AbstractService {
 
 
   public TransactionManager(Configuration config) {
-    this(config, new NoOpTransactionStateStorage(new SnapshotCodecProvider(config)), new TxMetricsCollector());
+    this(config, new NoOpTransactionStateStorage(new SnapshotCodecProvider(config)), new DefaultMetricsCollector());
   }
 
   @Inject
   public TransactionManager(Configuration conf, @Nonnull TransactionStateStorage persistor,
-                            TxMetricsCollector txMetricsCollector) {
+                            MetricsCollector txMetricsCollector) {
     this.persistor = persistor;
     cleanupInterval = conf.getInt(TxConstants.Manager.CFG_TX_CLEANUP_INTERVAL,
                                   TxConstants.Manager.DEFAULT_TX_CLEANUP_INTERVAL);
@@ -177,6 +178,7 @@ public class TransactionManager extends AbstractService {
     snapshotRetainCount = Math.max(conf.getInt(TxConstants.Manager.CFG_TX_SNAPSHOT_RETAIN,
                                                TxConstants.Manager.DEFAULT_TX_SNAPSHOT_RETAIN), 1);
     this.txMetricsCollector = txMetricsCollector;
+    this.txMetricsCollector.configure(conf);
     clear();
   }
 
@@ -198,6 +200,7 @@ public class TransactionManager extends AbstractService {
   @Override
   public synchronized void doStart() {
     LOG.info("Starting transaction manager.");
+    txMetricsCollector.start();
     // start up the persistor
     persistor.startAndWait();
     // establish defaults in case there is no persistence
@@ -294,6 +297,7 @@ public class TransactionManager extends AbstractService {
       public void doRun() {
         txMetricsCollector.gauge("committing.size", committingChangeSets.size());
         txMetricsCollector.gauge("committed.size", committedChangeSets.size());
+        txMetricsCollector.gauge("inprogress.size", inProgress.size());
         txMetricsCollector.gauge("invalid.size", invalidArray.length);
       }
 
@@ -302,6 +306,7 @@ public class TransactionManager extends AbstractService {
         // perform a final metrics emit
         txMetricsCollector.gauge("committing.size", committingChangeSets.size());
         txMetricsCollector.gauge("committed.size", committedChangeSets.size());
+        txMetricsCollector.gauge("inprogress.size", inProgress.size());
         txMetricsCollector.gauge("invalid.size", invalidArray.length);
       }
 
@@ -649,6 +654,7 @@ public class TransactionManager extends AbstractService {
     }
 
     persistor.stopAndWait();
+    txMetricsCollector.stop();
     timer.stop();
     LOG.info("Took " + timer + " to stop");
     notifyStopped();
@@ -683,11 +689,11 @@ public class TransactionManager extends AbstractService {
    */
   public Transaction startShort(int timeoutInSeconds) {
     Preconditions.checkArgument(timeoutInSeconds > 0, "timeout must be positive but is %s", timeoutInSeconds);
-    txMetricsCollector.gauge("start.short", 1);
+    txMetricsCollector.rate("start.short");
     Stopwatch timer = new Stopwatch().start();
     long expiration = getTxExpiration(timeoutInSeconds);
     Transaction tx = startTx(expiration, TransactionType.SHORT);
-    txMetricsCollector.gauge("start.short.latency", (int) timer.elapsedMillis());
+    txMetricsCollector.histogram("start.short.latency", (int) timer.elapsedMillis());
     return tx;
   }
   
@@ -711,11 +717,11 @@ public class TransactionManager extends AbstractService {
    * transaction moves it to the invalid list because we assume that its writes cannot be rolled back.
    */
   public Transaction startLong() {
-    txMetricsCollector.gauge("start.long", 1);
+    txMetricsCollector.rate("start.long");
     Stopwatch timer = new Stopwatch().start();
     long expiration = getTxExpiration(defaultLongTimeout);
     Transaction tx = startTx(expiration, TransactionType.LONG);
-    txMetricsCollector.gauge("start.long.latency", (int) timer.elapsedMillis());
+    txMetricsCollector.histogram("start.long.latency", (int) timer.elapsedMillis());
     return tx;
   }
 
@@ -750,7 +756,7 @@ public class TransactionManager extends AbstractService {
   }
 
   public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
-    txMetricsCollector.gauge("canCommit", 1);
+    txMetricsCollector.rate("canCommit");
     Stopwatch timer = new Stopwatch().start();
     if (inProgress.get(tx.getWritePointer()) == null) {
       // invalid transaction, either this has timed out and moved to invalid, or something else is wrong.
@@ -783,7 +789,7 @@ public class TransactionManager extends AbstractService {
     } finally {
       this.logReadLock.unlock();
     }
-    txMetricsCollector.gauge("canCommit.latency", (int) timer.elapsedMillis());
+    txMetricsCollector.histogram("canCommit.latency", (int) timer.elapsedMillis());
     return true;
   }
 
@@ -792,7 +798,7 @@ public class TransactionManager extends AbstractService {
   }
 
   public boolean commit(Transaction tx) throws TransactionNotInProgressException {
-    txMetricsCollector.gauge("commit", 1);
+    txMetricsCollector.rate("commit");
     Stopwatch timer = new Stopwatch().start();
     Set<ChangeId> changeSet = null;
     boolean addToCommitted = true;
@@ -837,7 +843,7 @@ public class TransactionManager extends AbstractService {
     } finally {
       this.logReadLock.unlock();
     }
-    txMetricsCollector.gauge("commit.latency", (int) timer.elapsedMillis());
+    txMetricsCollector.histogram("commit.latency", (int) timer.elapsedMillis());
     return true;
   }
 
@@ -879,7 +885,7 @@ public class TransactionManager extends AbstractService {
 
   public void abort(Transaction tx) {
     // guard against changes to the transaction log while processing
-    txMetricsCollector.gauge("abort", 1);
+    txMetricsCollector.rate("abort");
     Stopwatch timer = new Stopwatch().start();
     this.logReadLock.lock();
     try {
@@ -888,7 +894,7 @@ public class TransactionManager extends AbstractService {
         doAbort(tx.getWritePointer(), tx.getType());
       }
       appendToLog(TransactionEdit.createAborted(tx.getWritePointer(), tx.getType()));
-      txMetricsCollector.gauge("abort.latency", (int) timer.elapsedMillis());
+      txMetricsCollector.histogram("abort.latency", (int) timer.elapsedMillis());
     } finally {
       this.logReadLock.unlock();
     }
@@ -923,7 +929,7 @@ public class TransactionManager extends AbstractService {
 
   public boolean invalidate(long tx) {
     // guard against changes to the transaction log while processing
-    txMetricsCollector.gauge("invalidate", 1);
+    txMetricsCollector.rate("invalidate");
     Stopwatch timer = new Stopwatch().start();
     this.logReadLock.lock();
     try {
@@ -933,7 +939,7 @@ public class TransactionManager extends AbstractService {
         success = doInvalidate(tx);
       }
       appendToLog(TransactionEdit.createInvalid(tx));
-      txMetricsCollector.gauge("invalidate.latency", (int) timer.elapsedMillis());
+      txMetricsCollector.histogram("invalidate.latency", (int) timer.elapsedMillis());
       return success;
     } finally {
       this.logReadLock.unlock();
@@ -971,7 +977,7 @@ public class TransactionManager extends AbstractService {
    */
   public boolean truncateInvalidTx(Set<Long> invalidTxIds) {
     // guard against changes to the transaction log while processing
-    txMetricsCollector.gauge("truncateInvalidTx", 1);
+    txMetricsCollector.rate("truncateInvalidTx");
     Stopwatch timer = new Stopwatch().start();
     this.logReadLock.lock();
     try {
@@ -981,7 +987,7 @@ public class TransactionManager extends AbstractService {
         success = doTruncateInvalidTx(invalidTxIds);
       }
       appendToLog(TransactionEdit.createTruncateInvalidTx(invalidTxIds));
-      txMetricsCollector.gauge("truncateInvalidTx.latency", (int) timer.elapsedMillis());
+      txMetricsCollector.histogram("truncateInvalidTx.latency", (int) timer.elapsedMillis());
       return success;
     } finally {
       this.logReadLock.unlock();
@@ -1005,7 +1011,7 @@ public class TransactionManager extends AbstractService {
    */
   public boolean truncateInvalidTxBefore(long time) throws InvalidTruncateTimeException {
     // guard against changes to the transaction log while processing
-    txMetricsCollector.gauge("truncateInvalidTxBefore", 1);
+    txMetricsCollector.rate("truncateInvalidTxBefore");
     Stopwatch timer = new Stopwatch().start();
     this.logReadLock.lock();
     try {
@@ -1015,7 +1021,7 @@ public class TransactionManager extends AbstractService {
         success = doTruncateInvalidTxBefore(time);
       }
       appendToLog(TransactionEdit.createTruncateInvalidTxBefore(time));
-      txMetricsCollector.gauge("truncateInvalidTxBefore.latency", (int) timer.elapsedMillis());
+      txMetricsCollector.histogram("truncateInvalidTxBefore.latency", (int) timer.elapsedMillis());
       return success;
     } finally {
       this.logReadLock.unlock();
@@ -1123,7 +1129,8 @@ public class TransactionManager extends AbstractService {
     try {
       Stopwatch timer = new Stopwatch().start();
       currentLog.append(edit);
-      txMetricsCollector.gauge("append.edit", (int) timer.elapsedMillis());
+      txMetricsCollector.rate("wal.append.count");
+      txMetricsCollector.histogram("wal.append.latency", (int) timer.elapsedMillis());
     } catch (IOException ioe) {
       abortService("Error appending to transaction log", ioe);
     }
@@ -1133,7 +1140,8 @@ public class TransactionManager extends AbstractService {
     try {
       Stopwatch timer = new Stopwatch().start();
       currentLog.append(edits);
-      txMetricsCollector.gauge("append.edit", (int) timer.elapsedMillis());
+      txMetricsCollector.rate("wal.append.count", edits.size());
+      txMetricsCollector.histogram("wal.append.latency", (int) timer.elapsedMillis());
     } catch (IOException ioe) {
       abortService("Error appending to transaction log", ioe);
     }

--- a/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
@@ -248,6 +248,20 @@ public class TxConstants {
   }
 
   /**
+   * Configuration properties for metrics reporting
+   */
+  public static final class Metrics {
+    /**
+     * Frequency at which metrics should be reported, in seconds.
+     */
+    public static final String REPORT_PERIOD_KEY = "data.tx.metrics.period";
+    /**
+     * Default report period for metrics, in seconds.
+     */
+    public static final int REPORT_PERIOD_DEFAULT = 60;
+  }
+
+  /**
    * Configuration properties used by HBase
    */
   public static final class HBase {

--- a/tephra-core/src/main/java/co/cask/tephra/coprocessor/TransactionStateCache.java
+++ b/tephra-core/src/main/java/co/cask/tephra/coprocessor/TransactionStateCache.java
@@ -17,6 +17,7 @@
 package co.cask.tephra.coprocessor;
 
 import co.cask.tephra.TxConstants;
+import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.HDFSTransactionStateStorage;
 import co.cask.tephra.persist.TransactionSnapshot;
 import co.cask.tephra.persist.TransactionStateStorage;
@@ -85,7 +86,10 @@ public class TransactionStateCache extends AbstractIdleService implements Config
     try {
       Configuration conf = getSnapshotConfiguration();
       if (conf != null) {
-        this.storage = new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf));
+        // Since this is only used for background loading of transaction snapshots, we use the no-op metrics collector,
+        // as there are no relevant metrics to report
+        this.storage = new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf),
+            new TxMetricsCollector());
         this.storage.startAndWait();
         this.snapshotRefreshFrequency = conf.getLong(TxConstants.Manager.CFG_TX_SNAPSHOT_INTERVAL,
                                                      TxConstants.Manager.DEFAULT_TX_SNAPSHOT_INTERVAL) * 1000;

--- a/tephra-core/src/main/java/co/cask/tephra/metrics/DefaultMetricsCollector.java
+++ b/tephra-core/src/main/java/co/cask/tephra/metrics/DefaultMetricsCollector.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.metrics;
+
+import co.cask.tephra.TxConstants;
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Slf4jReporter;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Default metrics collector implementation using <a href="http://metrics.dropwizard.io">Yammer Metrics</a>.
+ *
+ * <p>The reporting frequency for this collector can be configured by setting the
+ * {@code data.tx.metrics.period} configuration property to the reporting frequency in seconds.
+ * </p>
+ */
+public class DefaultMetricsCollector extends TxMetricsCollector {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultMetricsCollector.class);
+
+  private final MetricRegistry metrics = new MetricRegistry();
+  private JmxReporter jmxReporter;
+  private ScheduledReporter reporter;
+  private int reportPeriod;
+  private ConcurrentMap<String, AtomicLong> gauges = Maps.newConcurrentMap();
+
+  @Override
+  public void configure(Configuration conf) {
+    // initialize selected output reporter
+    reportPeriod = conf.getInt(TxConstants.Metrics.REPORT_PERIOD_KEY, TxConstants.Metrics.REPORT_PERIOD_DEFAULT);
+    LOG.info("Configured metrics report to emit every {} seconds", reportPeriod);
+    // TODO: reporters should be pluggable based on injection
+    jmxReporter = JmxReporter.forRegistry(metrics).build();
+    reporter = Slf4jReporter.forRegistry(metrics)
+                            .outputTo(LoggerFactory.getLogger("tephra-metrics"))
+                            .convertRatesTo(TimeUnit.SECONDS)
+                            .convertDurationsTo(TimeUnit.MILLISECONDS)
+                            .build();
+  }
+
+
+  @Override
+  public void gauge(String metricName, int value, String... tags) {
+    AtomicLong gauge = gauges.get(metricName);
+    if (gauge == null) {
+      final AtomicLong newValue = new AtomicLong();
+      if (gauges.putIfAbsent(metricName, newValue) == null) {
+        // first to set the value, need to register the metric
+        metrics.register(metricName, new Gauge<Long>() {
+          @Override
+          public Long getValue() {
+            return newValue.get();
+          }
+        });
+        gauge = newValue;
+      } else {
+        // someone else set it first
+        gauge = gauges.get(metricName);
+      }
+    }
+    gauge.set(value);
+  }
+
+  @Override
+  public void histogram(String metricName, int value) {
+    metrics.histogram(metricName).update(value);
+  }
+
+  @Override
+  public void rate(String metricName) {
+    metrics.meter(metricName).mark();
+  }
+
+  @Override
+  public void rate(String metricName, int count) {
+    metrics.meter(metricName).mark(count);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    jmxReporter.start();
+    reporter.start(reportPeriod, TimeUnit.SECONDS);
+    LOG.info("Started metrics reporter");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    jmxReporter.stop();
+    reporter.stop();
+    LOG.info("Stopped metrics reporter");
+  }
+}

--- a/tephra-core/src/main/java/co/cask/tephra/metrics/MetricsCollector.java
+++ b/tephra-core/src/main/java/co/cask/tephra/metrics/MetricsCollector.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.metrics;
+
+import com.google.common.util.concurrent.Service;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Basic API for Tephra to support system metrics.
+ */
+public interface MetricsCollector extends Service {
+  /**
+   * Report a metric as an absolute value.
+   */
+  void gauge(String metricName, int value, String... tags);
+
+  /**
+   * Report a metric as a count over a given time duration.  This method uses an implicit count of 1.
+   */
+  void rate(String metricName);
+
+  /**
+   * Report a metric as a count over a given time duration.
+   */
+  void rate(String metricName, int count);
+
+  /**
+   * Report a metric calculating the distribution of the value.
+   */
+  void histogram(String metricName, int value);
+
+  /**
+   * Called before the collector service is started, allowing the collector to setup any
+   * required configuration.
+   */
+  void configure(Configuration conf);
+}

--- a/tephra-core/src/main/java/co/cask/tephra/metrics/TxMetricsCollector.java
+++ b/tephra-core/src/main/java/co/cask/tephra/metrics/TxMetricsCollector.java
@@ -16,17 +16,49 @@
 
 package co.cask.tephra.metrics;
 
+import com.google.common.util.concurrent.AbstractIdleService;
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Metrics Collector Class, to emit Transaction Related Metrics.
  * Note: This default implementation is a no-op and doesn't emit any metrics
  */
-public class TxMetricsCollector {
+public class TxMetricsCollector extends AbstractIdleService implements MetricsCollector {
 
-  /**
-   * Send metric value for a given metric, identified by the metricsName, can also be tagged
-   */
-  public void gauge(String metricName, int value, String...tags) {
-   //no-op
+  @Override
+  public void gauge(String metricName, int value, String... tags) {
+    //no-op
   }
 
+  @Override
+  public void rate(String metricName) {
+    // no-op
+  }
+
+  @Override
+  public void rate(String metricName, int count) {
+    // no-op
+  }
+
+  @Override
+  public void histogram(String metricName, int value) {
+    // no-op
+  }
+
+  @Override
+  public void configure(Configuration conf) {
+    // no-op
+  }
+
+  /* Service methods */
+
+  @Override
+  protected void startUp() throws Exception {
+    // no-op
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    // no-op
+  }
 }

--- a/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionLog.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionLog.java
@@ -16,6 +16,7 @@
 
 package co.cask.tephra.persist;
 
+import co.cask.tephra.metrics.MetricsCollector;
 import com.google.common.base.Throwables;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -46,8 +47,8 @@ public class HDFSTransactionLog extends AbstractTransactionLog {
    * @param logPath Path to the log file.
    */
   public HDFSTransactionLog(final FileSystem fs, final Configuration hConf,
-                            final Path logPath, long timestamp) {
-    super(timestamp);
+                            final Path logPath, long timestamp, MetricsCollector metricsCollector) {
+    super(timestamp, metricsCollector);
     this.fs = fs;
     this.hConf = hConf;
     this.logPath = logPath;

--- a/tephra-core/src/main/java/co/cask/tephra/persist/LocalFileTransactionLog.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/LocalFileTransactionLog.java
@@ -16,6 +16,8 @@
 
 package co.cask.tephra.persist;
 
+import co.cask.tephra.metrics.MetricsCollector;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -36,8 +38,8 @@ public class LocalFileTransactionLog extends AbstractTransactionLog {
    * Creates a new transaction log using the given file instance.
    * @param logFile The log file to use.
    */
-  public LocalFileTransactionLog(File logFile, long timestamp) {
-    super(timestamp);
+  public LocalFileTransactionLog(File logFile, long timestamp, MetricsCollector metricsCollector) {
+    super(timestamp, metricsCollector);
     this.logFile = logFile;
   }
 

--- a/tephra-core/src/main/java/co/cask/tephra/runtime/TransactionDistributedModule.java
+++ b/tephra-core/src/main/java/co/cask/tephra/runtime/TransactionDistributedModule.java
@@ -22,6 +22,8 @@ import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
 import co.cask.tephra.distributed.TransactionServiceClient;
+import co.cask.tephra.metrics.DefaultMetricsCollector;
+import co.cask.tephra.metrics.MetricsCollector;
 import co.cask.tephra.persist.HDFSTransactionStateStorage;
 import co.cask.tephra.persist.TransactionStateStorage;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
@@ -44,9 +46,10 @@ final class TransactionDistributedModule extends AbstractModule {
 
     bind(TransactionManager.class).in(Singleton.class);
     bind(TransactionSystemClient.class).to(TransactionServiceClient.class).in(Singleton.class);
+    bind(MetricsCollector.class).to(DefaultMetricsCollector.class).in(Singleton.class);
 
     install(new FactoryModuleBuilder()
-              .implement(TransactionExecutor.class, DefaultTransactionExecutor.class)
-              .build(TransactionExecutorFactory.class));
+        .implement(TransactionExecutor.class, DefaultTransactionExecutor.class)
+        .build(TransactionExecutorFactory.class));
   }
 }

--- a/tephra-core/src/main/java/co/cask/tephra/runtime/TransactionInMemoryModule.java
+++ b/tephra-core/src/main/java/co/cask/tephra/runtime/TransactionInMemoryModule.java
@@ -22,6 +22,8 @@ import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
 import co.cask.tephra.inmemory.InMemoryTxSystemClient;
+import co.cask.tephra.metrics.MetricsCollector;
+import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.NoOpTransactionStateStorage;
 import co.cask.tephra.persist.TransactionStateStorage;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
@@ -44,6 +46,8 @@ public class TransactionInMemoryModule extends AbstractModule {
     bind(TransactionStateStorage.class).to(NoOpTransactionStateStorage.class).in(Singleton.class);
     bind(TransactionManager.class).in(Singleton.class);
     bind(TransactionSystemClient.class).to(InMemoryTxSystemClient.class).in(Singleton.class);
+    // no metrics output for in-memory
+    bind(MetricsCollector.class).to(TxMetricsCollector.class);
 
     install(new FactoryModuleBuilder()
               .implement(TransactionExecutor.class, DefaultTransactionExecutor.class)

--- a/tephra-core/src/main/java/co/cask/tephra/runtime/TransactionLocalModule.java
+++ b/tephra-core/src/main/java/co/cask/tephra/runtime/TransactionLocalModule.java
@@ -22,6 +22,8 @@ import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
 import co.cask.tephra.inmemory.InMemoryTxSystemClient;
+import co.cask.tephra.metrics.DefaultMetricsCollector;
+import co.cask.tephra.metrics.MetricsCollector;
 import co.cask.tephra.persist.LocalFileTransactionStateStorage;
 import co.cask.tephra.persist.TransactionStateStorage;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
@@ -45,6 +47,7 @@ final class TransactionLocalModule extends AbstractModule {
 
     bind(TransactionManager.class).in(Singleton.class);
     bind(TransactionSystemClient.class).to(InMemoryTxSystemClient.class).in(Singleton.class);
+    bind(MetricsCollector.class).to(DefaultMetricsCollector.class);
 
     install(new FactoryModuleBuilder()
               .implement(TransactionExecutor.class, DefaultTransactionExecutor.class)

--- a/tephra-core/src/test/java/co/cask/tephra/persist/HDFSTransactionStateStorageTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/HDFSTransactionStateStorageTest.java
@@ -17,6 +17,7 @@
 package co.cask.tephra.persist;
 
 import co.cask.tephra.TxConstants;
+import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
 import co.cask.tephra.snapshot.SnapshotCodecV2;
 import org.apache.hadoop.conf.Configuration;
@@ -66,6 +67,6 @@ public class HDFSTransactionStateStorageTest extends AbstractTransactionStateSto
 
   @Override
   protected AbstractTransactionStateStorage getStorage(Configuration conf) {
-    return new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf));
+    return new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf), new TxMetricsCollector());
   }
 }

--- a/tephra-core/src/test/java/co/cask/tephra/persist/LocalTransactionStateStorageTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/LocalTransactionStateStorageTest.java
@@ -63,7 +63,7 @@ public class LocalTransactionStateStorageTest extends AbstractTransactionStateSt
 
   @Override
   protected AbstractTransactionStateStorage getStorage(Configuration conf) {
-    return new LocalFileTransactionStateStorage(conf, new SnapshotCodecProvider(conf));
+    return new LocalFileTransactionStateStorage(conf, new SnapshotCodecProvider(conf), new TxMetricsCollector());
   }
 
   // v2 TransactionEdit

--- a/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.94/src/test/java/co/cask/tephra/hbase94/coprocessor/TransactionProcessorTest.java
@@ -22,6 +22,7 @@ import co.cask.tephra.TransactionType;
 import co.cask.tephra.TxConstants;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
+import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.HDFSTransactionStateStorage;
 import co.cask.tephra.persist.TransactionSnapshot;
 import co.cask.tephra.snapshot.DefaultSnapshotCodec;
@@ -118,7 +119,7 @@ public class TransactionProcessorTest {
                                                                                         TransactionType.SHORT))),
         new HashMap<Long, Set<ChangeId>>(), new TreeMap<Long, Set<ChangeId>>());
     HDFSTransactionStateStorage tmpStorage =
-      new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf));
+      new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf), new TxMetricsCollector());
     tmpStorage.startAndWait();
     tmpStorage.writeSnapshot(txSnapshot);
     tmpStorage.stopAndWait();

--- a/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/coprocessor/TransactionProcessorTest.java
@@ -22,6 +22,7 @@ import co.cask.tephra.TransactionType;
 import co.cask.tephra.TxConstants;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
+import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.HDFSTransactionStateStorage;
 import co.cask.tephra.persist.TransactionSnapshot;
 import co.cask.tephra.snapshot.DefaultSnapshotCodec;
@@ -138,7 +139,7 @@ public class TransactionProcessorTest {
                                                                                         TransactionType.SHORT))),
         new HashMap<Long, Set<ChangeId>>(), new TreeMap<Long, Set<ChangeId>>());
     HDFSTransactionStateStorage tmpStorage =
-      new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf));
+      new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf), new TxMetricsCollector());
     tmpStorage.startAndWait();
     tmpStorage.writeSnapshot(txSnapshot);
     tmpStorage.stopAndWait();

--- a/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessorTest.java
@@ -22,6 +22,7 @@ import co.cask.tephra.TransactionType;
 import co.cask.tephra.TxConstants;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
+import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.HDFSTransactionStateStorage;
 import co.cask.tephra.persist.TransactionSnapshot;
 import co.cask.tephra.snapshot.DefaultSnapshotCodec;
@@ -140,7 +141,7 @@ public class TransactionProcessorTest {
                                                                                         TransactionType.SHORT))),
         new HashMap<Long, Set<ChangeId>>(), new TreeMap<Long, Set<ChangeId>>());
     HDFSTransactionStateStorage tmpStorage =
-      new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf));
+      new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf), new TxMetricsCollector());
     tmpStorage.startAndWait();
     tmpStorage.writeSnapshot(txSnapshot);
     tmpStorage.stopAndWait();


### PR DESCRIPTION
Currently Tephra only ships with a no-op stub for metrics collection.  This means that every user must implement their own MetricsCollector implementation, wire it in to the Guice injection, and compile and package Tephra in order to use it.

This change adds a built-in implementation based on Dropwizard Metrics, which supports JMX and file-based reporting out of the box.