### PR TITLE
TEPHRA-91 Clients should send normal Delete operations for deletes

### DIFF
--- a/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
@@ -80,6 +80,12 @@ public class TxConstants {
    * Key used to set the serialized transaction as an attribute on Get and Scan operations.
    */
   public static final String TX_OPERATION_ATTRIBUTE_KEY = "cask.tx";
+  /**
+   * Key used to flag a delete operation as part of a transaction rollback.  This is used so that the
+   * {@code TransactionProcessor} coprocessor loaded on a table can differentiate between deletes issued
+   * as part of a normal client operation versus those performed when rolling back a transaction.
+   */
+  public static final String TX_ROLLBACK_ATTRIBUTE_KEY = "cask.tx.rollback";
 
   // Constants for monitoring status
   public static final String STATUS_OK = "OK";

--- a/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/TransactionAwareHTable.java
@@ -25,6 +25,7 @@ import com.google.protobuf.Service;
 import com.google.protobuf.ServiceException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
@@ -133,6 +134,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
         byte[] qualifier = change.getQualifier();
         long transactionTimestamp = tx.getWritePointer();
         Delete rollbackDelete = new Delete(row);
+        rollbackDelete.setAttribute(TxConstants.TX_ROLLBACK_ATTRIBUTE_KEY, new byte[0]);
         switch (conflictLevel) {
           case ROW:
             // issue family delete for the tx write pointer
@@ -332,7 +334,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
     if (tx == null) {
       throw new IOException("Transaction not started");
     }
-    put(transactionalizeAction(delete));
+    hTable.delete(transactionalizeAction(delete));
   }
 
   @Override
@@ -340,12 +342,12 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
     if (tx == null) {
       throw new IOException("Transaction not started");
     }
-    List<Put> transactionalizedPuts = new ArrayList<Put>(deletes.size());
+    List<Delete> transactionalizedDeletes = new ArrayList<Delete>(deletes.size());
     for (Delete delete : deletes) {
-      Put txPut = transactionalizeAction(delete);
-      transactionalizedPuts.add(txPut);
+      Delete txDelete = transactionalizeAction(delete);
+      transactionalizedDeletes.add(txDelete);
     }
-    hTable.put(transactionalizedPuts);
+    hTable.delete(transactionalizedDeletes);
   }
 
   @Override
@@ -539,11 +541,11 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
     return txPut;
   }
 
-  private Put transactionalizeAction(Delete delete) throws IOException {
+  private Delete transactionalizeAction(Delete delete) throws IOException {
     long transactionTimestamp = tx.getWritePointer();
 
     byte[] deleteRow = delete.getRow();
-    Put txPut = new Put(deleteRow, transactionTimestamp);
+    Delete txDelete = new Delete(deleteRow, transactionTimestamp);
 
     Map<byte[], List<Cell>> familyToDelete = delete.getFamilyCellMap();
     if (familyToDelete.isEmpty()) {
@@ -553,7 +555,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
       for (Map.Entry<byte[], NavigableMap<byte[], byte[]>> familyEntry : resultMap.entrySet()) {
         NavigableMap<byte[], byte[]> familyColumns = result.getFamilyMap(familyEntry.getKey());
         for (Map.Entry<byte[], byte[]> column : familyColumns.entrySet()) {
-          txPut.add(familyEntry.getKey(), column.getKey(), transactionTimestamp, new byte[0]);
+          txDelete.deleteColumns(familyEntry.getKey(), column.getKey(), transactionTimestamp);
           addToChangeSet(deleteRow, familyEntry.getKey(), column.getKey());
         }
       }
@@ -561,23 +563,28 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
       for (Map.Entry<byte [], List<Cell>> familyEntry : familyToDelete.entrySet()) {
         byte[] family = familyEntry.getKey();
         List<Cell> entries = familyEntry.getValue();
-        if (entries.isEmpty()) {
-          Result result = get(new Get(delete.getRow()));
+        boolean isFamilyDelete = false;
+        if (entries.size() == 1) {
+          Cell cell = entries.get(0);
+          isFamilyDelete = CellUtil.isDeleteFamily(cell);
+        }
+        if (isFamilyDelete) {
+          Result result = get(new Get(delete.getRow()).addFamily(family));
           // Delete entire family
           NavigableMap<byte[], byte[]> familyColumns = result.getFamilyMap(family);
           for (Map.Entry<byte[], byte[]> column : familyColumns.entrySet()) {
-            txPut.add(family, column.getKey(), transactionTimestamp, new byte[0]);
+            txDelete.deleteColumns(family, column.getKey(), transactionTimestamp);
             addToChangeSet(deleteRow, family, column.getKey());
           }
         } else {
           for (Cell value : entries) {
-            txPut.add(value.getFamily(), value.getQualifier(), transactionTimestamp, new byte[0]);
+            txDelete.deleteColumns(value.getFamily(), value.getQualifier(), transactionTimestamp);
             addToChangeSet(deleteRow, value.getFamily(), value.getQualifier());
           }
         }
       }
     }
-    return txPut;
+    return txDelete;
   }
 
   private List<? extends Row> transactionalizeActions(List<? extends Row> actions) throws IOException {

--- a/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/TransactionAwareHTableTest.java
@@ -44,13 +44,17 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -60,6 +64,8 @@ import static org.junit.Assert.fail;
  * Tests for TransactionAwareHTables.
  */
 public class TransactionAwareHTableTest {
+  private static final Logger LOG = LoggerFactory.getLogger(TransactionAwareHTableTest.class);
+
   private static HBaseTestingUtility testUtil;
   private static HBaseAdmin hBaseAdmin;
   private static TransactionStateStorage txStateStorage;
@@ -70,10 +76,13 @@ public class TransactionAwareHTableTest {
 
   private static final class TestBytes {
     private static final byte[] table = Bytes.toBytes("testtable");
-    private static final byte[] family = Bytes.toBytes("testfamily");
-    private static final byte[] qualifier = Bytes.toBytes("testqualifier");
-    private static final byte[] row = Bytes.toBytes("testrow");
-    private static final byte[] value = Bytes.toBytes("testvalue");
+    private static final byte[] family = Bytes.toBytes("f1");
+    private static final byte[] family2 = Bytes.toBytes("f2");
+    private static final byte[] qualifier = Bytes.toBytes("col1");
+    private static final byte[] qualifier2 = Bytes.toBytes("col2");
+    private static final byte[] row = Bytes.toBytes("row");
+    private static final byte[] value = Bytes.toBytes("value");
+    private static final byte[] value2 = Bytes.toBytes("value2");
   }
 
   @BeforeClass
@@ -96,7 +105,7 @@ public class TransactionAwareHTableTest {
 
   @Before
   public void setupBeforeTest() throws Exception {
-    HTable hTable = createTable(TestBytes.table, TestBytes.family);
+    HTable hTable = createTable(TestBytes.table, new byte[][] {TestBytes.family});
     transactionAwareHTable = new TransactionAwareHTable(hTable);
     transactionContext = new TransactionContext(new InMemoryTxSystemClient(txManager), transactionAwareHTable);
   }
@@ -107,11 +116,13 @@ public class TransactionAwareHTableTest {
     hBaseAdmin.deleteTable(TestBytes.table);
   }
 
-  private HTable createTable(byte[] tableName, byte[] columnFamily) throws Exception {
+  private HTable createTable(byte[] tableName, byte[][] columnFamilies) throws Exception {
     HTableDescriptor desc = new HTableDescriptor(TableName.valueOf(tableName));
-    HColumnDescriptor columnDesc = new HColumnDescriptor(columnFamily);
-    columnDesc.setMaxVersions(Integer.MAX_VALUE);
-    desc.addFamily(columnDesc);
+    for (byte[] family : columnFamilies) {
+      HColumnDescriptor columnDesc = new HColumnDescriptor(family);
+      columnDesc.setMaxVersions(Integer.MAX_VALUE);
+      desc.addFamily(columnDesc);
+    }
     desc.addCoprocessor(TransactionProcessor.class.getName());
     hBaseAdmin.createTable(desc);
     testUtil.waitTableAvailable(tableName, 5000);
@@ -136,7 +147,7 @@ public class TransactionAwareHTableTest {
     transactionContext.finish();
 
     byte[] value = result.getValue(TestBytes.family, TestBytes.qualifier);
-    Assert.assertArrayEquals(TestBytes.value, value);
+    assertArrayEquals(TestBytes.value, value);
   }
 
   /**
@@ -157,7 +168,7 @@ public class TransactionAwareHTableTest {
     Result result = transactionAwareHTable.get(new Get(TestBytes.row));
     transactionContext.finish();
     byte[] value = result.getValue(TestBytes.family, TestBytes.qualifier);
-    Assert.assertArrayEquals(value, null);
+    assertArrayEquals(value, null);
   }
 
   /**
@@ -167,29 +178,142 @@ public class TransactionAwareHTableTest {
    */
   @Test
   public void testValidTransactionalDelete() throws Exception {
-    transactionContext.start();
-    Put put = new Put(TestBytes.row);
-    put.add(TestBytes.family, TestBytes.qualifier, TestBytes.value);
-    transactionAwareHTable.put(put);
-    transactionContext.finish();
+    HTable hTable = createTable(Bytes.toBytes("TestValidTransactionalDelete"),
+        new byte[][] {TestBytes.family, TestBytes.family2});
+    try {
+      TransactionAwareHTable txTable = new TransactionAwareHTable(hTable);
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
 
-    transactionContext.start();
-    Result result = transactionAwareHTable.get(new Get(TestBytes.row));
-    transactionContext.finish();
-    byte[] value = result.getValue(TestBytes.family, TestBytes.qualifier);
-    Assert.assertArrayEquals(TestBytes.value, value);
+      txContext.start();
+      Put put = new Put(TestBytes.row);
+      put.add(TestBytes.family, TestBytes.qualifier, TestBytes.value);
+      put.add(TestBytes.family2, TestBytes.qualifier, TestBytes.value2);
+      txTable.put(put);
+      txContext.finish();
 
-    transactionContext.start();
-    Delete delete = new Delete(TestBytes.row);
-    transactionAwareHTable.delete(delete);
+      txContext.start();
+      Result result = txTable.get(new Get(TestBytes.row));
+      txContext.finish();
+      byte[] value = result.getValue(TestBytes.family, TestBytes.qualifier);
+      assertArrayEquals(TestBytes.value, value);
+      value = result.getValue(TestBytes.family2, TestBytes.qualifier);
+      assertArrayEquals(TestBytes.value2, value);
 
-    transactionContext.finish();
+      // test full row delete
+      txContext.start();
+      Delete delete = new Delete(TestBytes.row);
+      txTable.delete(delete);
+      txContext.finish();
 
-    transactionContext.start();
-    result = transactionAwareHTable.get(new Get(TestBytes.row));
-    transactionContext.finish();
-    value = result.getValue(TestBytes.family, TestBytes.qualifier);
-    assertNull(value);
+      txContext.start();
+      result = txTable.get(new Get(TestBytes.row));
+      txContext.finish();
+      assertTrue(result.isEmpty());
+
+      // test column delete
+      // load 10 rows
+      txContext.start();
+      int rowCount = 10;
+      for (int i = 0; i < rowCount; i++) {
+        Put p = new Put(Bytes.toBytes("row" + i));
+        for (int j = 0; j < 10; j++) {
+          p.add(TestBytes.family, Bytes.toBytes(j), TestBytes.value);
+        }
+        txTable.put(p);
+      }
+      txContext.finish();
+
+      // verify loaded rows
+      txContext.start();
+      for (int i = 0; i < rowCount; i++) {
+        Get g = new Get(Bytes.toBytes("row" + i));
+        Result r = txTable.get(g);
+        assertFalse(r.isEmpty());
+        for (int j = 0; j < 10; j++) {
+          assertArrayEquals(TestBytes.value, r.getValue(TestBytes.family, Bytes.toBytes(j)));
+        }
+      }
+      txContext.finish();
+
+      // delete odds columns from odd rows and even columns from even rows
+      txContext.start();
+      for (int i = 0; i < rowCount; i++) {
+        Delete d = new Delete(Bytes.toBytes("row" + i));
+        for (int j = 0; j < 10; j++) {
+          if (i % 2 == j % 2) {
+            LOG.info("Deleting row={}, column={}", i, j);
+            d.deleteColumns(TestBytes.family, Bytes.toBytes(j));
+          }
+        }
+        txTable.delete(d);
+      }
+      txContext.finish();
+
+      // verify deleted columns
+      txContext.start();
+      for (int i = 0; i < rowCount; i++) {
+        Get g = new Get(Bytes.toBytes("row" + i));
+        Result r = txTable.get(g);
+        assertEquals(5, r.size());
+        for (Map.Entry<byte[], byte[]> entry : r.getFamilyMap(TestBytes.family).entrySet()) {
+          int col = Bytes.toInt(entry.getKey());
+          LOG.info("Got row={}, col={}", i, col);
+          // each row should only have the opposite mod (odd=even, even=odd)
+          assertNotEquals(i % 2, col % 2);
+          assertArrayEquals(TestBytes.value, entry.getValue());
+        }
+      }
+      txContext.finish();
+
+      // test family delete
+      // load 10 rows
+      txContext.start();
+      for (int i = 0; i < rowCount; i++) {
+        Put p = new Put(Bytes.toBytes("famrow" + i));
+        p.add(TestBytes.family, TestBytes.qualifier, TestBytes.value);
+        p.add(TestBytes.family2, TestBytes.qualifier2, TestBytes.value2);
+        txTable.put(p);
+      }
+      txContext.finish();
+
+      // verify all loaded rows
+      txContext.start();
+      for (int i = 0; i < rowCount; i++) {
+        Get g = new Get(Bytes.toBytes("famrow" + i));
+        Result r = txTable.get(g);
+        assertEquals(2, r.size());
+        assertArrayEquals(TestBytes.value, r.getValue(TestBytes.family, TestBytes.qualifier));
+        assertArrayEquals(TestBytes.value2, r.getValue(TestBytes.family2, TestBytes.qualifier2));
+      }
+      txContext.finish();
+
+      // delete family1 for even rows, family2 for odd rows
+      txContext.start();
+      for (int i = 0; i < rowCount; i++) {
+        Delete d = new Delete(Bytes.toBytes("famrow" + i));
+        d.deleteFamily((i % 2 == 0) ? TestBytes.family : TestBytes.family2);
+        txTable.delete(d);
+      }
+      txContext.finish();
+
+      // verify deleted families
+      txContext.start();
+      for (int i = 0; i < rowCount; i++) {
+        Get g = new Get(Bytes.toBytes("famrow" + i));
+        Result r = txTable.get(g);
+        assertEquals(1, r.size());
+        if (i % 2 == 0) {
+          assertNull(r.getValue(TestBytes.family, TestBytes.qualifier));
+          assertArrayEquals(TestBytes.value2, r.getValue(TestBytes.family2, TestBytes.qualifier2));
+        } else {
+          assertArrayEquals(TestBytes.value, r.getValue(TestBytes.family, TestBytes.qualifier));
+          assertNull(r.getValue(TestBytes.family2, TestBytes.qualifier2));
+        }
+      }
+      txContext.finish();
+    } finally {
+      hTable.close();
+    }
   }
 
   /**

--- a/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessorTest.java
@@ -224,15 +224,18 @@ public class TransactionProcessorTest {
 
       byte[] row = Bytes.toBytes(1);
       for (int i = 4; i < V.length; i++) {
-        if (i != 5) {
-          Put p = new Put(row);
-          p.add(familyBytes, columnBytes, V[i], Bytes.toBytes(V[i]));
-          region.put(p);
-        }
+        Put p = new Put(row);
+        p.add(familyBytes, columnBytes, V[i], Bytes.toBytes(V[i]));
+        region.put(p);
       }
 
       // delete from the third entry back
-      Delete d = new Delete(row, V[5]);
+      // take that cell's timestamp + 1 to simulate a delete in a new tx
+      long deleteTs = V[5] + 1;
+      Delete d = new Delete(row, deleteTs);
+      LOG.info("Issuing delete at timestamp " + deleteTs);
+      // row deletes are not yet supported (TransactionAwareHTable normally handles this)
+      d.deleteColumns(familyBytes, columnBytes);
       region.delete(d);
 
       List<Cell> results = Lists.newArrayList();
@@ -249,7 +252,9 @@ public class TransactionProcessorTest {
       RegionScanner regionScanner = region.getScanner(scan);
       // should be only one row
       assertFalse(regionScanner.next(results));
-      assertKeyValueMatches(results, 1, new long[]{V[8], V[6]});
+      assertKeyValueMatches(results, 1,
+          new long[]{V[8], V[6], deleteTs},
+          new byte[][]{Bytes.toBytes(V[8]), Bytes.toBytes(V[6]), new byte[0]});
     } finally {
       region.close();
     }
@@ -386,12 +391,21 @@ public class TransactionProcessorTest {
   }
 
   private void assertKeyValueMatches(List<Cell> results, int index, long[] versions) {
+    byte[][] values = new byte[versions.length][];
+    for (int i = 0; i < versions.length; i++) {
+      values[i] = Bytes.toBytes(versions[i]);
+    }
+    assertKeyValueMatches(results, index, versions, values);
+  }
+
+  private void assertKeyValueMatches(List<Cell> results, int index, long[] versions, byte[][] values) {
     assertEquals(versions.length, results.size());
+    assertEquals(values.length, results.size());
     for (int i = 0; i < versions.length; i++) {
       Cell kv = results.get(i);
       assertArrayEquals(Bytes.toBytes(index), kv.getRow());
       assertEquals(versions[i], kv.getTimestamp());
-      assertArrayEquals(Bytes.toBytes(versions[i]), kv.getValue());
+      assertArrayEquals(values[i], kv.getValue());
     }
   }
 


### PR DESCRIPTION
This changes the HBase 0.96 and 0.98 TransactionAwareHTable implementations to pass Delete operations from the client when a delete is performed.  This will decouple client-side change set tracking from server-side implementation details of how delete markers are handled.

This is not supported in HBase 0.94, since the server-side row lock obtained outside the coprocessor hook in HBase 0.94 does not allow us to perform a Put operation on the same row as the Delete is being performed upon.