### PR TITLE
TEPHRA-70 Add support for row delete markers when using row-level conflict detection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -492,15 +492,20 @@ to a user:
 Known Issues and Limitations
 ----------------------------
 
-- Currently, ``Delete`` operations are implemented by writing a empty value (empty ``byte[]``) to the
-  column.  This is necessary so that the changes can be rolled back in the case of a transaction
-  failure -- normal HBase ``Delete`` operations cannot be undone.
-- Invalid transactions are not cleared from the exclusion list.  When a transaction is
+- Currently, column family ``Delete`` operations are implemented by writing a cell with an empty
+  qualifier (empty ``byte[]``) and empty value (empty ``byte[]``).  This is done in place of
+  native HBase ``Delete`` operations so the delete marker can be rolled back in the event of
+  a transaction failure -- normal HBase ``Delete`` operations cannot be undone.  However, this
+  means that applications that store data in a column with an empty qualifier will not be able to
+  store empty values, and will not be able to transactionally delete that column.
+- Column ``Delete`` operations are implemented by writing a empty value (empty ``byte[]``) to the
+  column.  This means that applications will not be able to store empty values to columns.
+- Invalid transactions are not automatically cleared from the exclusion list.  When a transaction is
   invalidated, either from timing out or being invalidated by the client due to a failure to rollback
   changes, its transaction ID is added to a list of excluded transactions.  Data from invalidated
   transactions will be dropped by the ``TransactionProcessor`` coprocessor on HBase region flush
-  and compaction operations.  Currently, however, the transaction ID is not removed from the list
-  of excluded transaction IDs.
+  and compaction operations.  Currently, however, transaction IDs can only be manually removed
+  from the list of excluded transaction IDs, using the ``co.cask.tephra.TransactionAdmin`` tool.
 
 
 How to Contribute

--- a/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
@@ -87,6 +87,11 @@ public class TxConstants {
    */
   public static final String TX_ROLLBACK_ATTRIBUTE_KEY = "cask.tx.rollback";
 
+  /**
+   * Column qualifier used for a special delete marker tombstone, which identifies an entire column family as deleted.
+   */
+  public static final byte[] FAMILY_DELETE_QUALIFIER = new byte[0];
+
   // Constants for monitoring status
   public static final String STATUS_OK = "OK";
   public static final String STATUS_NOTOK = "NOTOK";

--- a/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/TransactionAwareHTable.java
@@ -521,14 +521,20 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
 
     Map<byte[], List<Cell>> familyToDelete = delete.getFamilyCellMap();
     if (familyToDelete.isEmpty()) {
-      Result result = get(new Get(delete.getRow()));
-      // Delete everything
-      NavigableMap<byte[], NavigableMap<byte[], byte[]>> resultMap = result.getNoVersionMap();
-      for (Map.Entry<byte[], NavigableMap<byte[], byte[]>> familyEntry : resultMap.entrySet()) {
-        NavigableMap<byte[], byte[]> familyColumns = result.getFamilyMap(familyEntry.getKey());
-        for (Map.Entry<byte[], byte[]> column : familyColumns.entrySet()) {
-          txDelete.deleteColumns(familyEntry.getKey(), column.getKey(), transactionTimestamp);
-          addToChangeSet(deleteRow, familyEntry.getKey(), column.getKey());
+      // perform a row delete is we are using row-level conflict detection
+      if (conflictLevel == TxConstants.ConflictDetection.ROW) {
+        // no need to identify individual columns deleted
+        addToChangeSet(deleteRow, null, null);
+      } else {
+        Result result = get(new Get(delete.getRow()));
+        // Delete everything
+        NavigableMap<byte[], NavigableMap<byte[], byte[]>> resultMap = result.getNoVersionMap();
+        for (Map.Entry<byte[], NavigableMap<byte[], byte[]>> familyEntry : resultMap.entrySet()) {
+          NavigableMap<byte[], byte[]> familyColumns = result.getFamilyMap(familyEntry.getKey());
+          for (Map.Entry<byte[], byte[]> column : familyColumns.entrySet()) {
+            txDelete.deleteColumns(familyEntry.getKey(), column.getKey(), transactionTimestamp);
+            addToChangeSet(deleteRow, familyEntry.getKey(), column.getKey());
+          }
         }
       }
     } else {
@@ -541,12 +547,18 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
           isFamilyDelete = CellUtil.isDeleteFamily(cell);
         }
         if (isFamilyDelete) {
-          Result result = get(new Get(delete.getRow()).addFamily(family));
-          // Delete entire family
-          NavigableMap<byte[], byte[]> familyColumns = result.getFamilyMap(family);
-          for (Map.Entry<byte[], byte[]> column : familyColumns.entrySet()) {
-            txDelete.deleteColumns(family, column.getKey(), transactionTimestamp);
-            addToChangeSet(deleteRow, family, column.getKey());
+          if (conflictLevel == TxConstants.ConflictDetection.ROW) {
+            // no need to identify individual columns deleted
+            txDelete.deleteFamily(family);
+            addToChangeSet(deleteRow, null, null);
+          } else {
+            Result result = get(new Get(delete.getRow()).addFamily(family));
+            // Delete entire family
+            NavigableMap<byte[], byte[]> familyColumns = result.getFamilyMap(family);
+            for (Map.Entry<byte[], byte[]> column : familyColumns.entrySet()) {
+              txDelete.deleteColumns(family, column.getKey(), transactionTimestamp);
+              addToChangeSet(deleteRow, family, column.getKey());
+            }
           }
         } else {
           for (Cell value : entries) {

--- a/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/TransactionAwareHTableTest.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -81,6 +83,8 @@ public class TransactionAwareHTableTest {
     private static final byte[] qualifier = Bytes.toBytes("col1");
     private static final byte[] qualifier2 = Bytes.toBytes("col2");
     private static final byte[] row = Bytes.toBytes("row");
+    private static final byte[] row2 = Bytes.toBytes("row2");
+    private static final byte[] row3 = Bytes.toBytes("row3");
     private static final byte[] value = Bytes.toBytes("value");
     private static final byte[] value2 = Bytes.toBytes("value2");
   }
@@ -176,7 +180,7 @@ public class TransactionAwareHTableTest {
   @Test
   public void testValidTransactionalDelete() throws Exception {
     HTable hTable = createTable(Bytes.toBytes("TestValidTransactionalDelete"),
-        new byte[][] {TestBytes.family, TestBytes.family2});
+        new byte[][]{TestBytes.family, TestBytes.family2});
     try {
       TransactionAwareHTable txTable = new TransactionAwareHTable(hTable);
       TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
@@ -341,6 +345,158 @@ public class TransactionAwareHTableTest {
     transactionContext.finish();
     value = result.getValue(TestBytes.family, TestBytes.qualifier);
     assertArrayEquals(TestBytes.value, value);
+  }
+
+  @Test
+  public void testRowDelete() throws Exception {
+    HTable hTable = createTable(Bytes.toBytes("TestRowDelete"), new byte[][] {TestBytes.family, TestBytes.family2});
+    TransactionAwareHTable txTable = new TransactionAwareHTable(hTable, TxConstants.ConflictDetection.ROW);
+    try {
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+
+      // Test 1: full row delete
+      txContext.start();
+      txTable.put(new Put(TestBytes.row)
+              .add(TestBytes.family, TestBytes.qualifier, TestBytes.value)
+              .add(TestBytes.family, TestBytes.qualifier2, TestBytes.value2)
+              .add(TestBytes.family2, TestBytes.qualifier, TestBytes.value)
+              .add(TestBytes.family2, TestBytes.qualifier2, TestBytes.value2));
+      txContext.finish();
+
+      txContext.start();
+      Get get = new Get(TestBytes.row);
+      Result result = txTable.get(get);
+      assertFalse(result.isEmpty());
+      assertArrayEquals(TestBytes.value, result.getValue(TestBytes.family, TestBytes.qualifier));
+      assertArrayEquals(TestBytes.value2, result.getValue(TestBytes.family, TestBytes.qualifier2));
+      assertArrayEquals(TestBytes.value, result.getValue(TestBytes.family2, TestBytes.qualifier));
+      assertArrayEquals(TestBytes.value2, result.getValue(TestBytes.family2, TestBytes.qualifier2));
+      txContext.finish();
+
+      // delete entire row
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row));
+      txContext.finish();
+
+      // verify row is now empty
+      txContext.start();
+      result = txTable.get(new Get(TestBytes.row));
+      assertTrue(result.isEmpty());
+
+      // verify row is empty for explicit column retrieval
+      result = txTable.get(new Get(TestBytes.row)
+              .addColumn(TestBytes.family, TestBytes.qualifier)
+              .addFamily(TestBytes.family2));
+      assertTrue(result.isEmpty());
+
+      // verify row is empty for scan
+      ResultScanner scanner = txTable.getScanner(new Scan(TestBytes.row));
+      assertNull(scanner.next());
+      scanner.close();
+
+      // verify row is empty for scan with explicit column
+      scanner = txTable.getScanner(new Scan(TestBytes.row).addColumn(TestBytes.family2, TestBytes.qualifier2));
+      assertNull(scanner.next());
+      scanner.close();
+      txContext.finish();
+
+      // write swapped values to one column per family
+      txContext.start();
+      txTable.put(new Put(TestBytes.row)
+              .add(TestBytes.family, TestBytes.qualifier, TestBytes.value2)
+              .add(TestBytes.family2, TestBytes.qualifier2, TestBytes.value));
+      txContext.finish();
+
+      // verify new values appear
+      txContext.start();
+      result = txTable.get(new Get(TestBytes.row));
+      assertFalse(result.isEmpty());
+      assertEquals(2, result.size());
+      assertArrayEquals(TestBytes.value2, result.getValue(TestBytes.family, TestBytes.qualifier));
+      assertArrayEquals(TestBytes.value, result.getValue(TestBytes.family2, TestBytes.qualifier2));
+
+      scanner = txTable.getScanner(new Scan(TestBytes.row));
+      Result result1 = scanner.next();
+      assertNotNull(result1);
+      assertFalse(result1.isEmpty());
+      assertEquals(2, result1.size());
+      assertArrayEquals(TestBytes.value2, result.getValue(TestBytes.family, TestBytes.qualifier));
+      assertArrayEquals(TestBytes.value, result.getValue(TestBytes.family2, TestBytes.qualifier2));
+      scanner.close();
+      txContext.finish();
+
+      // Test 2: delete of first column family
+      txContext.start();
+      txTable.put(new Put(TestBytes.row2)
+              .add(TestBytes.family, TestBytes.qualifier, TestBytes.value)
+              .add(TestBytes.family, TestBytes.qualifier2, TestBytes.value2)
+              .add(TestBytes.family2, TestBytes.qualifier, TestBytes.value)
+              .add(TestBytes.family2, TestBytes.qualifier2, TestBytes.value2));
+      txContext.finish();
+
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row2).deleteFamily(TestBytes.family));
+      txContext.finish();
+
+      txContext.start();
+      Result fam1Result = txTable.get(new Get(TestBytes.row2));
+      assertFalse(fam1Result.isEmpty());
+      assertEquals(2, fam1Result.size());
+      assertArrayEquals(TestBytes.value, fam1Result.getValue(TestBytes.family2, TestBytes.qualifier));
+      assertArrayEquals(TestBytes.value2, fam1Result.getValue(TestBytes.family2, TestBytes.qualifier2));
+      txContext.finish();
+
+      // Test 3: delete of second column family
+      txContext.start();
+      txTable.put(new Put(TestBytes.row3)
+              .add(TestBytes.family, TestBytes.qualifier, TestBytes.value)
+              .add(TestBytes.family, TestBytes.qualifier2, TestBytes.value2)
+              .add(TestBytes.family2, TestBytes.qualifier, TestBytes.value)
+              .add(TestBytes.family2, TestBytes.qualifier2, TestBytes.value2));
+      txContext.finish();
+
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row3).deleteFamily(TestBytes.family2));
+      txContext.finish();
+
+      txContext.start();
+      Result fam2Result = txTable.get(new Get(TestBytes.row3));
+      assertFalse(fam2Result.isEmpty());
+      assertEquals(2, fam2Result.size());
+      assertArrayEquals(TestBytes.value, fam2Result.getValue(TestBytes.family, TestBytes.qualifier));
+      assertArrayEquals(TestBytes.value2, fam2Result.getValue(TestBytes.family, TestBytes.qualifier2));
+      txContext.finish();
+
+      // Test 4: delete specific rows in a range
+      txContext.start();
+      for (int i = 0; i < 10; i++) {
+        txTable.put(new Put(Bytes.toBytes("z" + i))
+                .add(TestBytes.family, TestBytes.qualifier, Bytes.toBytes(i))
+                .add(TestBytes.family2, TestBytes.qualifier2, Bytes.toBytes(i)));
+      }
+      txContext.finish();
+
+      txContext.start();
+      // delete odd rows
+      for (int i = 1; i < 10; i += 2) {
+        txTable.delete(new Delete(Bytes.toBytes("z" + i)));
+      }
+      txContext.finish();
+
+      txContext.start();
+      int cnt = 0;
+      ResultScanner zScanner = txTable.getScanner(new Scan(Bytes.toBytes("z0")));
+      Result res;
+      while ((res = zScanner.next()) != null) {
+        assertFalse(res.isEmpty());
+        assertArrayEquals(Bytes.toBytes("z" + cnt), res.getRow());
+        assertArrayEquals(Bytes.toBytes(cnt), res.getValue(TestBytes.family, TestBytes.qualifier));
+        assertArrayEquals(Bytes.toBytes(cnt), res.getValue(TestBytes.family2, TestBytes.qualifier2));
+        cnt += 2;
+      }
+    } finally {
+      txTable.close();
+    }
   }
 
   /**

--- a/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/coprocessor/TransactionVisibilityFilter.java
+++ b/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/coprocessor/TransactionVisibilityFilter.java
@@ -21,6 +21,7 @@ import co.cask.tephra.TxConstants;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterBase;
 import org.apache.hadoop.hbase.regionserver.ScanType;
@@ -50,6 +51,8 @@ public class TransactionVisibilityFilter extends FilterBase {
   // since we traverse KVs in order, cache the current oldest TS to avoid map lookups per KV
   private byte[] currentFamily = new byte[0];
   private long currentOldestTs;
+
+  private DeleteTracker deleteTracker = new DeleteTracker();
 
   /**
    * Creates a new {@link org.apache.hadoop.hbase.filter.Filter} for returning data only from visible transactions.
@@ -99,6 +102,7 @@ public class TransactionVisibilityFilter extends FilterBase {
       currentFamily = CellUtil.cloneFamily(cell);
       Long familyOldestTs = oldestTsByFamily.get(currentFamily);
       currentOldestTs = familyOldestTs != null ? familyOldestTs : 0;
+      deleteTracker.reset();
     }
     // need to apply TTL for the column family here
     long kvTimestamp = cell.getTimestamp();
@@ -106,6 +110,19 @@ public class TransactionVisibilityFilter extends FilterBase {
       // passed TTL for this column, seek to next
       return ReturnCode.NEXT_COL;
     } else if (tx.isVisible(kvTimestamp)) {
+      if (deleteTracker.isFamilyDelete(cell)) {
+        deleteTracker.addFamilyDelete(cell);
+        if (clearDeletes) {
+          return ReturnCode.NEXT_COL;
+        } else {
+          return ReturnCode.INCLUDE_AND_NEXT_COL;
+        }
+      }
+      // check if masked by family delete
+      if (deleteTracker.isDeleted(cell)) {
+        return ReturnCode.NEXT_COL;
+      }
+      // check for column delete
       if (cell.getValueLength() == 0 && !allowEmptyValues) {
         if (clearDeletes) {
           // skip "deleted" cell
@@ -128,7 +145,33 @@ public class TransactionVisibilityFilter extends FilterBase {
   }
 
   @Override
+  public void reset() {
+    deleteTracker.reset();
+  }
+
+  @Override
   public byte[] toByteArray() throws IOException {
     return super.toByteArray();
+  }
+
+  private static final class DeleteTracker {
+    private long familyDeleteTs;
+
+    public boolean isFamilyDelete(Cell cell) {
+      return CellUtil.matchingQualifier(cell, TxConstants.FAMILY_DELETE_QUALIFIER) &&
+              CellUtil.matchingValue(cell, HConstants.EMPTY_BYTE_ARRAY);
+    }
+
+    public void addFamilyDelete(Cell delete) {
+      this.familyDeleteTs = delete.getTimestamp();
+    }
+
+    public boolean isDeleted(Cell cell) {
+      return cell.getTimestamp() < familyDeleteTs;
+    }
+
+    public void reset() {
+      this.familyDeleteTs = 0;
+    }
   }
 }


### PR DESCRIPTION
When using row-level conflict detection, and performing a row or column family delete, TransactionAwareHTable will now issue a row or family delete operation.  Previously, TransactionAwareHTable would first read all the columns in the row or family, and issue individual column deletes on each one.  At the moment, row and family deletes can only be supported with row-level conflict detection, since with column-level conflict detection, the TransactionAwareHTable must first find which columns would be deleted in order to include them in the change set.

TransactionProcessor has been updated to know how to handle column family delete markers, and to inject the family delete marker column into all read operations.