### PR TITLE
Fix deadlock in PooledClientProvider

### DIFF
--- a/tephra-core/src/main/java/co/cask/tephra/distributed/AbstractClientProvider.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/AbstractClientProvider.java
@@ -56,8 +56,9 @@ public abstract class AbstractClientProvider implements ThriftClientProvider {
   }
 
   public void initialize() throws TException {
-    // initialize the service discovery client
-    this.initDiscovery();
+    if (initialized.compareAndSet(false, true)) {
+      this.initDiscovery();
+    }
   }
 
   /**
@@ -83,9 +84,7 @@ public abstract class AbstractClientProvider implements ThriftClientProvider {
   }
 
   protected TransactionServiceThriftClient newClient(int timeout) throws TException {
-    if (initialized.compareAndSet(false, true)) {
-      initialize();
-    }
+    initialize();
     String address;
     int port;
 

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/ElasticPool.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/ElasticPool.java
@@ -86,7 +86,7 @@ public abstract class ElasticPool<T, E extends Exception> {
   private BlockingQueue<T> elements;
 
   // number of current acvtive elements (including ones that are in use)
-  int size = 0;
+  volatile int size = 0;
 
   // the limit for the number of active elements
   int limit;

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/PooledClientProvider.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/PooledClientProvider.java
@@ -59,8 +59,7 @@ public class PooledClientProvider extends AbstractClientProvider {
     super(conf, discoveryServiceClient);
   }
 
-  @Override
-  public void initialize() throws TException {
+  private void initializePool() throws TException {
     // initialize the super class (needed for service discovery)
     super.initialize();
 
@@ -105,7 +104,7 @@ public class PooledClientProvider extends AbstractClientProvider {
     synchronized (this) {
       if (clients == null) {
         try {
-          initialize();
+          initializePool();
         } catch (TException e) {
           LOG.error("Failed to initialize Tx client provider", e);
           throw Throwables.propagate(e);

--- a/tephra-core/src/test/java/co/cask/tephra/distributed/PooledClientProviderTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/distributed/PooledClientProviderTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.tephra.distributed;
+
+import co.cask.tephra.TransactionServiceMain;
+import co.cask.tephra.TxConstants;
+import co.cask.tephra.runtime.ConfigModule;
+import co.cask.tephra.runtime.DiscoveryModules;
+import co.cask.tephra.runtime.TransactionClientModule;
+import co.cask.tephra.runtime.TransactionModules;
+import co.cask.tephra.runtime.ZKModule;
+import com.google.common.base.Throwables;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.internal.zookeeper.InMemoryZKServer;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class PooledClientProviderTest {
+
+  public static final int MAX_CLIENT_COUNT = 3;
+
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Test
+  public void testClientConnectionPoolMaximumNumberOfClients() throws Exception {
+    // We need a server for the client to connect to
+    InMemoryZKServer zkServer = InMemoryZKServer.builder().setDataDir(tmpFolder.newFolder()).build();
+    zkServer.startAndWait();
+
+    try {
+      Configuration conf = new Configuration();
+      conf.set(TxConstants.Service.CFG_DATA_TX_ZOOKEEPER_QUORUM, zkServer.getConnectionStr());
+      conf.set(TxConstants.Manager.CFG_TX_SNAPSHOT_DIR, tmpFolder.newFolder().getAbsolutePath());
+      conf.set("data.tx.client.count", Integer.toString(MAX_CLIENT_COUNT));
+
+      final TransactionServiceMain main = new TransactionServiceMain(conf);
+      final CountDownLatch latch = new CountDownLatch(1);
+      Thread t = new Thread() {
+        @Override
+        public void run() {
+          try {
+            main.start();
+            latch.countDown();
+          } catch (Exception e) {
+            throw Throwables.propagate(e);
+          }
+        }
+      };
+
+      try {
+        t.start();
+        // Wait for service to startup
+        latch.await();
+
+        startClientAndTestPool(conf);
+      } finally {
+        main.stop();
+        t.join();
+      }
+    } finally {
+      zkServer.stopAndWait();
+    }
+  }
+
+  private void startClientAndTestPool(Configuration conf) throws InterruptedException, ExecutionException {
+    Injector injector = Guice.createInjector(
+      new ConfigModule(conf),
+      new ZKModule(),
+      new DiscoveryModules().getDistributedModules(),
+      new TransactionModules().getDistributedModules(),
+      new TransactionClientModule()
+    );
+
+    ZKClientService zkClient = injector.getInstance(ZKClientService.class);
+    zkClient.startAndWait();
+
+    final PooledClientProvider clientProvider = new PooledClientProvider(conf,
+      injector.getInstance(DiscoveryServiceClient.class));
+
+    //Now race to get MAX_CLIENT_COUNT+1 clients, exhausting the pool and requesting 1 more.
+    List<Future<Integer>> clientIds = new ArrayList<Future<Integer>>();
+    ExecutorService executor = Executors.newFixedThreadPool(MAX_CLIENT_COUNT + 2);
+    for (int i = 0; i < MAX_CLIENT_COUNT + 1; i++) {
+      clientIds.add(executor.submit(new RetrieveClient(clientProvider)));
+    }
+
+    Set<Integer> ids = new HashSet<Integer>();
+    for (Future<Integer> id : clientIds) {
+      ids.add(id.get());
+    }
+    executor.shutdown();
+    Assert.assertEquals(MAX_CLIENT_COUNT, ids.size());
+  }
+
+  private static class RetrieveClient implements Callable<Integer> {
+    private final PooledClientProvider pool;
+
+    public RetrieveClient(PooledClientProvider pool) {
+      this.pool = pool;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+      TransactionServiceThriftClient client = pool.getClient();
+      int id = System.identityHashCode(client);
+      try {
+        //"use" the client
+        Thread.sleep(100);
+      } finally {
+        pool.returnClient(client);
+      }
+      return id;
+    }
+  }
+}


### PR DESCRIPTION
When more threads then the size of the client pool try to get a client in parallel this either results in a deadlock (just try to run the provided test without the fixes) or the `ElasticPool`'s internal queue overflows when one client too much is returned to the pool (with only the fix in the `AbstractClientProvider`).

Cause was that the pool was initialized twice. Once from within the pools `getClientPool()` method and once when creating the first client in the `newClient()` method. I solved this by creating a custom `initializePool()` method instead of overriding the original `initialize()` method.