### PR TITLE
(TEPHRA-117) Added the TransactionContext.removeTransactionAware method

### DIFF
--- a/tephra-core/src/main/java/co/cask/tephra/TransactionContext.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TransactionContext.java
@@ -44,8 +44,8 @@ public class TransactionContext {
   }
 
   public TransactionContext(TransactionSystemClient txClient, Iterable<TransactionAware> txAwares) {
-    // Use a set to avoid adding the same TransactionAware twice and makes removal faster.
-    // Use a linked hash set so that insertion order is preserved (same behavior when it was using a List).
+    // Use a set to avoid adding the same TransactionAware twice and to make removal faster.
+    // Use a linked hash set so that insertion order is preserved (same behavior as when it was using a List).
     this.txAwares = Sets.newLinkedHashSet(txAwares);
     this.txClient = txClient;
   }
@@ -64,8 +64,8 @@ public class TransactionContext {
   }
 
   /**
-   * Removes a {@link TransactionAware} to withdraw from participation in the transaction. Withdrawal is only allowed
-   * if there is no active transaction.
+   * Removes a {@link TransactionAware} and withdraws from participation in the transaction.
+   * Withdrawal is only allowed if there is no active transaction.
    *
    * @param txAware the {@link TransactionAware} to be removed
    * @return true if the given {@link TransactionAware} is removed; false otherwise.
@@ -135,7 +135,7 @@ public class TransactionContext {
    * instances, and obtaining a new current write pointer for the transaction.  By performing a checkpoint,
    * the client can ensure that all previous writes were flushed and are visible.  By default, the current write
    * pointer for the transaction is also visible.  The current write pointer can be excluded from read
-   * operations by calling {@link Transaction#setVisibility(Transaction.VisibilityLevel)} with visibility level set
+   * operations by calling {@link Transaction#setVisibility(Transaction.VisibilityLevel)} with the visibility level set
    * to {@link Transaction.VisibilityLevel#SNAPSHOT_EXCLUDE_CURRENT} on the {@link Transaction} instance created
    * by the checkpoint call, which can be retrieved by calling {@link #getCurrentTransaction()}.
    *

--- a/tephra-core/src/test/java/co/cask/tephra/TransactionContextTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/TransactionContextTest.java
@@ -20,7 +20,7 @@ import co.cask.tephra.inmemory.InMemoryTxSystemClient;
 import co.cask.tephra.runtime.ConfigModule;
 import co.cask.tephra.runtime.DiscoveryModules;
 import co.cask.tephra.runtime.TransactionModules;
-import co.cask.tephra.snapshot.SnapshotCodecV2;
+import co.cask.tephra.snapshot.SnapshotCodecV4;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
@@ -53,7 +53,7 @@ public class TransactionContextTest {
   @BeforeClass
   public static void setup() throws IOException {
     final Configuration conf = new Configuration();
-    conf.set(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES, SnapshotCodecV2.class.getName());
+    conf.set(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES, SnapshotCodecV4.class.getName());
     conf.set(TxConstants.Manager.CFG_TX_SNAPSHOT_DIR, tmpFolder.newFolder().getAbsolutePath());
     Injector injector = Guice.createInjector(
       new ConfigModule(conf),
@@ -153,7 +153,7 @@ public class TransactionContextTest {
     // commit transaction should fail and cause rollback
     try {
       context.finish();
-      Assert.fail("persist failed - exception should be thrown");
+      Assert.fail("Persist should have failed - exception should be thrown");
     } catch (TransactionFailureException e) {
       Assert.assertEquals("persist failure", e.getCause().getMessage());
     }
@@ -183,7 +183,7 @@ public class TransactionContextTest {
     // commit transaction should fail and cause rollback
     try {
       context.finish();
-      Assert.fail("persist failed - exception should be thrown");
+      Assert.fail("Persist should have failed - exception should be thrown");
     } catch (TransactionFailureException e) {
       Assert.assertNull(e.getCause()); // in this case, the ds simply returned false
     }
@@ -214,7 +214,7 @@ public class TransactionContextTest {
     // commit transaction should fail and cause rollback
     try {
       context.finish();
-      Assert.fail("persist failed - exception should be thrown");
+      Assert.fail("Persist should have failed - exception should be thrown");
     } catch (TransactionFailureException e) {
       Assert.assertEquals("persist failure", e.getCause().getMessage());
     }
@@ -245,7 +245,7 @@ public class TransactionContextTest {
     // commit transaction should fail and cause rollback
     try {
       context.finish();
-      Assert.fail("persist failed - exception should be thrown");
+      Assert.fail("Persist should have failed - exception should be thrown");
     } catch (TransactionFailureException e) {
       Assert.assertNull(e.getCause()); // in this case, the ds simply returned false
     }
@@ -422,7 +422,7 @@ public class TransactionContextTest {
     // commit transaction should fail and cause rollback
     try {
       context.finish();
-      Assert.fail("persist failed - exception should be thrown");
+      Assert.fail("Persist should have failed - exception should be thrown");
     } catch (TransactionFailureException e) {
       Assert.assertEquals("persist failure", e.getCause().getMessage());
     }
@@ -458,7 +458,7 @@ public class TransactionContextTest {
     context.finish();
 
     Assert.assertTrue(context.removeTransactionAware(ds1));
-    // Remove a TransactionAware not added before should returns false
+    // Removing a TransactionAware not added before should returns false
     Assert.assertFalse(context.removeTransactionAware(ds2));
 
     // Verify ds1 is committed and post-committed
@@ -489,7 +489,7 @@ public class TransactionContextTest {
 
     try {
       context.finish();
-      Assert.fail("persist failed - exception should be thrown");
+      Assert.fail("Persist should have failed - exception should be thrown");
     } catch (TransactionFailureException e) {
       Assert.assertEquals("persist failure", e.getCause().getMessage());
     }


### PR DESCRIPTION
- Removal is only allowed if there is no active transaction
  - This is the prevent the TransactionAware being left in some unknown state