### PR TITLE
Feature/tephra 130

### DIFF
--- a/tephra-core/src/main/java/co/cask/tephra/TransactionManager.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TransactionManager.java
@@ -212,6 +212,11 @@ public class TransactionManager extends AbstractService {
     txMetricsCollector.start();
     // start up the persistor
     persistor.startAndWait();
+    try {
+      persistor.setupStorage();
+    } catch (IOException e) {
+      Throwables.propagate(e);
+    }
     // establish defaults in case there is no persistence
     clear();
     // attempt to recover state from last run

--- a/tephra-core/src/main/java/co/cask/tephra/coprocessor/TransactionStateCache.java
+++ b/tephra-core/src/main/java/co/cask/tephra/coprocessor/TransactionStateCache.java
@@ -89,7 +89,7 @@ public class TransactionStateCache extends AbstractIdleService implements Config
         // Since this is only used for background loading of transaction snapshots, we use the no-op metrics collector,
         // as there are no relevant metrics to report
         this.storage = new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf),
-            new TxMetricsCollector());
+                                                       new TxMetricsCollector());
         this.storage.startAndWait();
         this.snapshotRefreshFrequency = conf.getLong(TxConstants.Manager.CFG_TX_SNAPSHOT_INTERVAL,
                                                      TxConstants.Manager.DEFAULT_TX_SNAPSHOT_INTERVAL) * 1000;

--- a/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionStateStorage.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionStateStorage.java
@@ -105,10 +105,6 @@ public class HDFSTransactionStateStorage extends AbstractTransactionStateStorage
     }
     snapshotDir = new Path(configuredSnapshotDir);
     LOG.info("Using snapshot dir " + snapshotDir);
-    if (!fs.exists(snapshotDir)) {
-      LOG.info("Creating snapshot dir at {}", snapshotDir);
-      fs.mkdirs(snapshotDir);
-    }
   }
 
   @Override
@@ -261,6 +257,17 @@ public class HDFSTransactionStateStorage extends AbstractTransactionStateStorage
       }
     }
     LOG.debug("Removed {} transaction logs older than {}", removedCnt, timestamp);
+  }
+
+  @Override
+  public void setupStorage() throws IOException {
+    if (!fs.exists(snapshotDir)) {
+      LOG.info("Creating snapshot dir at {}", snapshotDir);
+      fs.mkdirs(snapshotDir);
+    } else {
+      Preconditions.checkState(fs.isDirectory(snapshotDir),
+                               "Configured snapshot directory " + snapshotDir + " is not a directory!");
+    }
   }
 
   @Override

--- a/tephra-core/src/main/java/co/cask/tephra/persist/LocalFileTransactionStateStorage.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/LocalFileTransactionStateStorage.java
@@ -75,19 +75,7 @@ public class LocalFileTransactionStateStorage extends AbstractTransactionStateSt
     Preconditions.checkState(configuredSnapshotDir != null,
         "Snapshot directory is not configured.  Please set " + TxConstants.Manager.CFG_TX_SNAPSHOT_LOCAL_DIR +
         " in configuration.");
-    // create the directory if it doesn't exist
     snapshotDir = new File(configuredSnapshotDir);
-    if (!snapshotDir.exists()) {
-      if (!snapshotDir.mkdirs()) {
-        throw new IOException("Failed to create directory " + configuredSnapshotDir +
-                              " for transaction snapshot storage");
-      }
-    } else {
-      Preconditions.checkState(snapshotDir.isDirectory(),
-          "Configured snapshot directory " + configuredSnapshotDir + " is not a directory!");
-      Preconditions.checkState(snapshotDir.canWrite(),
-          "Configured snapshot directory " + configuredSnapshotDir + " exists but is not writable!");
-    }
   }
 
   @Override
@@ -245,6 +233,22 @@ public class LocalFileTransactionStateStorage extends AbstractTransactionStateSt
   }
 
   @Override
+  public void setupStorage() throws IOException {
+    // create the directory if it doesn't exist
+    if (!snapshotDir.exists()) {
+      if (!snapshotDir.mkdirs()) {
+        throw new IOException("Failed to create directory " + configuredSnapshotDir +
+                                " for transaction snapshot storage");
+      }
+    } else {
+      Preconditions.checkState(snapshotDir.isDirectory(),
+                               "Configured snapshot directory " + configuredSnapshotDir + " is not a directory!");
+      Preconditions.checkState(snapshotDir.canWrite(), "Configured snapshot directory " +
+        configuredSnapshotDir + " exists but is not writable!");
+    }
+  }
+
+  @Override
   public List<String> listLogs() throws IOException {
     File[] logs = snapshotDir.listFiles(new LogFileFilter(0, Long.MAX_VALUE));
     return Lists.transform(Arrays.asList(logs), new Function<File, String>() {
@@ -281,7 +285,6 @@ public class LocalFileTransactionStateStorage extends AbstractTransactionStateSt
       return false;
     }
   }
-
 
   /**
    * Represents a filename composed of a prefix and a ".timestamp" suffix.  This is useful for manipulating both

--- a/tephra-core/src/main/java/co/cask/tephra/persist/NoOpTransactionStateStorage.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/NoOpTransactionStateStorage.java
@@ -67,12 +67,12 @@ public class NoOpTransactionStateStorage extends AbstractIdleService implements 
 
   @Override
   public List<String> listSnapshots() throws IOException {
-    return new ArrayList<String>(0);
+    return new ArrayList<>(0);
   }
 
   @Override
   public List<TransactionLog> getLogsSince(long timestamp) throws IOException {
-    return new ArrayList<TransactionLog>(0);
+    return new ArrayList<>(0);
   }
 
   @Override
@@ -85,8 +85,12 @@ public class NoOpTransactionStateStorage extends AbstractIdleService implements 
   }
 
   @Override
+  public void setupStorage() throws IOException {
+  }
+
+  @Override
   public List<String> listLogs() throws IOException {
-    return new ArrayList<String>(0);
+    return new ArrayList<>(0);
   }
 
   @Override

--- a/tephra-core/src/main/java/co/cask/tephra/persist/TransactionSnapshot.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/TransactionSnapshot.java
@@ -189,12 +189,12 @@ public class TransactionSnapshot {
     // for committing and committed maps, we need to copy each individual Set as well to prevent modification
     Map<Long, Set<ChangeId>> committingCopy = Maps.newHashMap();
     for (Map.Entry<Long, Set<ChangeId>> entry : committing.entrySet()) {
-      committingCopy.put(entry.getKey(), new HashSet<ChangeId>(entry.getValue()));
+      committingCopy.put(entry.getKey(), new HashSet<>(entry.getValue()));
     }
 
-    NavigableMap<Long, Set<ChangeId>> committedCopy = new TreeMap<Long, Set<ChangeId>>();
+    NavigableMap<Long, Set<ChangeId>> committedCopy = new TreeMap<>();
     for (Map.Entry<Long, Set<ChangeId>> entry : committed.entrySet()) {
-      committedCopy.put(entry.getKey(), new HashSet<ChangeId>(entry.getValue()));
+      committedCopy.put(entry.getKey(), new HashSet<>(entry.getValue()));
     }
 
     return new TransactionSnapshot(snapshotTime, readPointer, writePointer,

--- a/tephra-core/src/main/java/co/cask/tephra/persist/TransactionStateStorage.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/TransactionStateStorage.java
@@ -82,6 +82,12 @@ public interface TransactionStateStorage extends Service {
   public void deleteLogsOlderThan(long timestamp) throws IOException;
 
   /**
+   * Create the directories required for the transaction state stage.
+   * @throws IOException If an error occurred during the creation of required directories for transaction state storage.
+   */
+  public void setupStorage() throws IOException;
+
+  /**
    * Returns a string representation of the location used for persistence.
    */
   public String getLocation();

--- a/tephra-core/src/test/java/co/cask/tephra/persist/InMemoryTransactionStateStorage.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/InMemoryTransactionStateStorage.java
@@ -36,7 +36,7 @@ public class InMemoryTransactionStateStorage extends AbstractIdleService impleme
   // only keeps the most recent snapshot in memory
   private TransactionSnapshot lastSnapshot;
 
-  private NavigableMap<Long, TransactionLog> logs = new TreeMap<Long, TransactionLog>();
+  private NavigableMap<Long, TransactionLog> logs = new TreeMap<>();
 
   @Override
   protected void startUp() throws Exception {
@@ -45,7 +45,7 @@ public class InMemoryTransactionStateStorage extends AbstractIdleService impleme
   @Override
   protected void shutDown() throws Exception {
     lastSnapshot = null;
-    logs = new TreeMap<Long, TransactionLog>();
+    logs = new TreeMap<>();
   }
 
   @Override
@@ -99,6 +99,10 @@ public class InMemoryTransactionStateStorage extends AbstractIdleService impleme
         logIter.remove();
       }
     }
+  }
+
+  @Override
+  public void setupStorage() throws IOException {
   }
 
   @Override

--- a/tephra-examples/src/main/java/co/cask/tephra/examples/BalanceBooks.java
+++ b/tephra-examples/src/main/java/co/cask/tephra/examples/BalanceBooks.java
@@ -122,7 +122,7 @@ public class BalanceBooks implements Closeable {
    * Runs all clients and waits for them to complete.
    */
   public void run() throws IOException, InterruptedException {
-    List<Client> clients = new ArrayList<Client>(totalClients);
+    List<Client> clients = new ArrayList<>(totalClients);
     for (int i = 0; i < totalClients; i++) {
       Client c = new Client(i, totalClients, iterations);
       c.init(txClient, conn.getTable(TABLE));


### PR DESCRIPTION
Create tx snapshot directory only in the Tx Manager and not in coprocessors. 

Approach: Add a ``setupStorage`` step in TxStateStorage which is called only by the TxManager instead of creating it in the constructor of TxStateStorage.

JIRA : https://issues.cask.co/browse/TEPHRA-130