### PR TITLE
Feature/tephra 113

### DIFF
--- a/tephra-core/src/main/java/co/cask/tephra/distributed/ElasticPool.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/ElasticPool.java
@@ -85,14 +85,14 @@ public abstract class ElasticPool<T, E extends Exception> {
   // holds all currently available elements
   private BlockingQueue<T> elements;
 
-  // number of current acvtive elements (including ones that are in use)
+  // number of current active elements (including ones that are in use)
   volatile int size = 0;
 
   // the limit for the number of active elements
   int limit;
 
   public ElasticPool(int sizeLimit) {
-    elements = new ArrayBlockingQueue<T>(sizeLimit);
+    elements = new ArrayBlockingQueue<>(sizeLimit);
     limit = sizeLimit;
     size = 0;
   }

--- a/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionStateStorage.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionStateStorage.java
@@ -145,6 +145,19 @@ public class HDFSTransactionStateStorage extends AbstractTransactionStateStorage
     }
   }
 
+  @Override
+  public TransactionVisibilityState getLatestTransactionVisibilityState() throws IOException {
+    InputStream in = getLatestSnapshotInputStream();
+    if (in == null) {
+      return null;
+    }
+    try {
+      return readTransactionVisibilityStateFromInputStream(in);
+    } finally {
+      in.close();
+    }
+  }
+
   private InputStream getLatestSnapshotInputStream() throws IOException {
     TimestampedFilename[] snapshots = listSnapshotFiles();
     Arrays.sort(snapshots);
@@ -162,6 +175,13 @@ public class HDFSTransactionStateStorage extends AbstractTransactionStateStorage
     TransactionSnapshot snapshot = codecProvider.decode(countingIn);
     LOG.info("Read encoded transaction snapshot of {} bytes", countingIn.getCount());
     return snapshot;
+  }
+
+  private TransactionVisibilityState readTransactionVisibilityStateFromInputStream(InputStream in) throws IOException {
+    CountingInputStream countingIn = new CountingInputStream(in);
+    TransactionVisibilityState state = codecProvider.decodeTransactionVisibilityState(countingIn);
+    LOG.info("Read encoded transaction snapshot of {} bytes", countingIn.getCount());
+    return state;
   }
 
   private TransactionSnapshot readSnapshotFile(Path filePath) throws IOException {

--- a/tephra-core/src/main/java/co/cask/tephra/persist/LocalFileTransactionStateStorage.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/LocalFileTransactionStateStorage.java
@@ -125,6 +125,19 @@ public class LocalFileTransactionStateStorage extends AbstractTransactionStateSt
     }
   }
 
+  @Override
+  public TransactionVisibilityState getLatestTransactionVisibilityState() throws IOException {
+    InputStream is = getLatestSnapshotInputStream();
+    if (is == null) {
+      return null;
+    }
+    try {
+      return codecProvider.decodeTransactionVisibilityState(is);
+    } finally {
+      is.close();
+    }
+  }
+
   private InputStream getLatestSnapshotInputStream() throws IOException {
     File[] snapshotFiles = snapshotDir.listFiles(SNAPSHOT_FILE_FILTER);
     TimestampedFilename mostRecent = null;

--- a/tephra-core/src/main/java/co/cask/tephra/persist/NoOpTransactionStateStorage.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/NoOpTransactionStateStorage.java
@@ -61,6 +61,11 @@ public class NoOpTransactionStateStorage extends AbstractIdleService implements 
   }
 
   @Override
+  public TransactionVisibilityState getLatestTransactionVisibilityState() throws IOException {
+    return null;
+  }
+
+  @Override
   public long deleteOldSnapshots(int numberToKeep) throws IOException {
     return 0;
   }

--- a/tephra-core/src/main/java/co/cask/tephra/persist/TransactionStateStorage.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/TransactionStateStorage.java
@@ -44,6 +44,13 @@ public interface TransactionStateStorage extends Service {
   public TransactionSnapshot getLatestSnapshot() throws IOException;
 
   /**
+   * Returns the most recent transaction visibility state that has been successfully written.
+   * Note that this may return {@code null} if no completed snapshot files are found.
+   * @return {@link TransactionVisibilityState}
+   */
+  public TransactionVisibilityState getLatestTransactionVisibilityState() throws IOException;
+
+  /**
    * Removes any snapshots prior to the {@code numberToKeep} most recent.
    *
    * @param numberToKeep The number of most recent snapshots to keep.

--- a/tephra-core/src/main/java/co/cask/tephra/persist/TransactionVisibilityState.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/TransactionVisibilityState.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.persist;
+
+import co.cask.tephra.TransactionManager;
+
+import java.util.Collection;
+import java.util.NavigableMap;
+
+/**
+ * Transaction Visibility state contains information required by TransactionProcessor CoProcessor
+ * to determine cell visibility.
+ */
+public interface TransactionVisibilityState {
+
+  /**
+   * Returns the timestamp from when this snapshot was created.
+   */
+  long getTimestamp();
+
+  /**
+   * Returns the read pointer at the time of the snapshot.
+   */
+  long getReadPointer();
+
+  /**
+   * Returns the next write pointer at the time of the snapshot.
+   */
+  long getWritePointer();
+
+  /**
+   * Returns the list of invalid write pointers at the time of the snapshot.
+   */
+  Collection<Long> getInvalid();
+
+  /**
+   * Returns the map of write pointers to in-progress transactions at the time of the snapshot.
+   */
+  NavigableMap<Long, TransactionManager.InProgressTx> getInProgress();
+
+  /**
+   * @return transaction id {@code X} such that any of the transactions newer than {@code X} might be invisible to
+   *         some of the currently in-progress transactions or to those that will be started <p>
+   *         NOTE: the returned tx id can be invalid.
+   */
+  long getVisibilityUpperBound();
+}

--- a/tephra-core/src/main/java/co/cask/tephra/snapshot/DefaultSnapshotCodec.java
+++ b/tephra-core/src/main/java/co/cask/tephra/snapshot/DefaultSnapshotCodec.java
@@ -19,6 +19,7 @@ package co.cask.tephra.snapshot;
 import co.cask.tephra.ChangeId;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.persist.TransactionSnapshot;
+import co.cask.tephra.persist.TransactionVisibilityState;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -75,16 +76,28 @@ public class DefaultSnapshotCodec implements SnapshotCodec {
     BinaryDecoder decoder = new BinaryDecoder(in);
 
     try {
+      TransactionVisibilityState minTxSnapshot = decodeTransactionVisibilityState(in);
+      NavigableMap<Long, Set<ChangeId>> committing = decodeChangeSets(decoder);
+      NavigableMap<Long, Set<ChangeId>> committed = decodeChangeSets(decoder);
+      return new TransactionSnapshot(minTxSnapshot.getTimestamp(), minTxSnapshot.getReadPointer(),
+                                     minTxSnapshot.getWritePointer(), minTxSnapshot.getInvalid(),
+                                     minTxSnapshot.getInProgress(), committing, committed);
+    } catch (IOException e) {
+      LOG.error("Unable to deserialize transaction state: ", e);
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public TransactionVisibilityState decodeTransactionVisibilityState(InputStream in) {
+    BinaryDecoder decoder = new BinaryDecoder(in);
+    try {
       long timestamp = decoder.readLong();
       long readPointer = decoder.readLong();
       long writePointer = decoder.readLong();
       Collection<Long> invalid = decodeInvalid(decoder);
       NavigableMap<Long, TransactionManager.InProgressTx> inProgress = decodeInProgress(decoder);
-      NavigableMap<Long, Set<ChangeId>> committing = decodeChangeSets(decoder);
-      NavigableMap<Long, Set<ChangeId>> committed = decodeChangeSets(decoder);
-
-      return new TransactionSnapshot(timestamp, readPointer, writePointer, invalid, inProgress,
-                                     committing, committed);
+      return new TransactionSnapshot(timestamp, readPointer, writePointer, invalid, inProgress);
     } catch (IOException e) {
       LOG.error("Unable to deserialize transaction state: ", e);
       throw Throwables.propagate(e);

--- a/tephra-core/src/main/java/co/cask/tephra/snapshot/SnapshotCodec.java
+++ b/tephra-core/src/main/java/co/cask/tephra/snapshot/SnapshotCodec.java
@@ -17,6 +17,7 @@
 package co.cask.tephra.snapshot;
 
 import co.cask.tephra.persist.TransactionSnapshot;
+import co.cask.tephra.persist.TransactionVisibilityState;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -46,4 +47,10 @@ public interface SnapshotCodec {
    */
   TransactionSnapshot decode(InputStream in);
 
+  /**
+   * Decode transaction visibility state from an input stream.
+   * @param in the input stream to read from
+   * @return {@link TransactionVisibilityState}
+   */
+  TransactionVisibilityState decodeTransactionVisibilityState(InputStream in);
 }

--- a/tephra-core/src/main/java/co/cask/tephra/util/TxUtils.java
+++ b/tephra-core/src/main/java/co/cask/tephra/util/TxUtils.java
@@ -20,7 +20,7 @@ import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionType;
 import co.cask.tephra.TxConstants;
-import co.cask.tephra.persist.TransactionSnapshot;
+import co.cask.tephra.persist.TransactionVisibilityState;
 import com.google.common.primitives.Longs;
 
 import java.util.Map;
@@ -61,17 +61,17 @@ public class TxUtils {
   }
 
   /**
-   * Creates a "dummy" transaction based on the given snapshot's state.  This is not a "real" transaction in the
-   * sense that it has not been started, data should not be written with it, and it cannot be committed.  However,
-   * this can still be useful for filtering data according to the snapshot's state.  Instead of the actual
-   * write pointer from the snapshot, however, we use {@code Long.MAX_VALUE} to avoid mis-identifying any cells as
-   * being written by this transaction (and therefore visible).
+   * Creates a "dummy" transaction based on the given txVisibilityState's state.  This is not a "real" transaction in
+   * the sense that it has not been started, data should not be written with it, and it cannot be committed.  However,
+   * this can still be useful for filtering data according to the txVisibilityState's state.  Instead of the actual
+   * write pointer from the txVisibilityState, however, we use {@code Long.MAX_VALUE} to avoid mis-identifying any cells
+   * as being written by this transaction (and therefore visible).
    */
-  public static Transaction createDummyTransaction(TransactionSnapshot snapshot) {
-    return new Transaction(snapshot.getReadPointer(), Long.MAX_VALUE,
-                           Longs.toArray(snapshot.getInvalid()),
-                           Longs.toArray(snapshot.getInProgress().keySet()),
-                           TxUtils.getFirstShortInProgress(snapshot.getInProgress()), TransactionType.SHORT);
+  public static Transaction createDummyTransaction(TransactionVisibilityState txVisibilityState) {
+    return new Transaction(txVisibilityState.getReadPointer(), Long.MAX_VALUE,
+                           Longs.toArray(txVisibilityState.getInvalid()),
+                           Longs.toArray(txVisibilityState.getInProgress().keySet()),
+                           TxUtils.getFirstShortInProgress(txVisibilityState.getInProgress()), TransactionType.SHORT);
   }
 
   /**

--- a/tephra-core/src/test/java/co/cask/tephra/persist/InMemoryTransactionStateStorage.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/InMemoryTransactionStateStorage.java
@@ -64,6 +64,11 @@ public class InMemoryTransactionStateStorage extends AbstractIdleService impleme
   }
 
   @Override
+  public TransactionVisibilityState getLatestTransactionVisibilityState() throws IOException {
+    return lastSnapshot;
+  }
+
+  @Override
   public long deleteOldSnapshots(int numberToKeep) throws IOException {
     // always only keep the last snapshot
     return lastSnapshot.getTimestamp();

--- a/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/coprocessor/TransactionProcessor.java
@@ -22,7 +22,7 @@ import co.cask.tephra.TxConstants;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.hbase96.Filters;
-import co.cask.tephra.persist.TransactionSnapshot;
+import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.util.TxUtils;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
@@ -263,7 +263,7 @@ public class TransactionProcessor extends BaseRegionObserver {
   }
 
   protected InternalScanner createStoreScanner(RegionCoprocessorEnvironment env, String action,
-                                               TransactionSnapshot snapshot, Store store,
+                                               TransactionVisibilityState snapshot, Store store,
                                                List<? extends KeyValueScanner> scanners, ScanType type,
                                                long earliestPutTs) throws IOException {
     if (snapshot == null) {

--- a/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/co/cask/tephra/hbase96/coprocessor/TransactionProcessorTest.java
@@ -25,6 +25,7 @@ import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.HDFSTransactionStateStorage;
 import co.cask.tephra.persist.TransactionSnapshot;
+import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.snapshot.DefaultSnapshotCodec;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
 import co.cask.tephra.util.TxUtils;
@@ -113,7 +114,7 @@ public class TransactionProcessorTest {
   private static MiniDFSCluster dfsCluster;
   private static Configuration conf;
   private static LongArrayList invalidSet = new LongArrayList(new long[]{V[3], V[5], V[7]});
-  private static TransactionSnapshot txSnapshot;
+  private static TransactionVisibilityState txVisibilityState;
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
@@ -131,13 +132,16 @@ public class TransactionProcessorTest {
     conf.set(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES, DefaultSnapshotCodec.class.getName());
 
     // write an initial transaction snapshot
-    txSnapshot =
+    TransactionSnapshot txSnapshot =
       TransactionSnapshot.copyFrom(
         System.currentTimeMillis(), V[6] - 1, V[7], invalidSet,
         // this will set visibility upper bound to V[6]
         Maps.newTreeMap(ImmutableSortedMap.of(V[6], new TransactionManager.InProgressTx(V[6] - 1, Long.MAX_VALUE,
                                                                                         TransactionType.SHORT))),
         new HashMap<Long, Set<ChangeId>>(), new TreeMap<Long, Set<ChangeId>>());
+    txVisibilityState = new TransactionSnapshot(txSnapshot.getTimestamp(), txSnapshot.getReadPointer(),
+                                                txSnapshot.getWritePointer(), txSnapshot.getInvalid(),
+                                                txSnapshot.getInProgress());
     HDFSTransactionStateStorage tmpStorage =
       new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf), new TxMetricsCollector());
     tmpStorage.startAndWait();
@@ -248,8 +252,8 @@ public class TransactionProcessorTest {
       // should be only one row
       assertFalse(regionScanner.next(results));
       assertKeyValueMatches(results, 1,
-          new long[]{V[8], V[6], deleteTs},
-          new byte[][]{Bytes.toBytes(V[8]), Bytes.toBytes(V[6]), new byte[0]});
+                            new long[]{V[8], V[6], deleteTs},
+                            new byte[][]{Bytes.toBytes(V[8]), Bytes.toBytes(V[6]), new byte[0]});
     } finally {
       region.close();
     }
@@ -264,7 +268,7 @@ public class TransactionProcessorTest {
       region.initialize();
 
       // all puts use a timestamp before the tx snapshot's visibility upper bound, making them eligible for removal
-      long writeTs = txSnapshot.getVisibilityUpperBound() - 10;
+      long writeTs = txVisibilityState.getVisibilityUpperBound() - 10;
       // deletes are performed after the writes, but still before the visibility upper bound
       long deleteTs = writeTs + 1;
       // write separate columns to confirm that delete markers survive across flushes
@@ -307,7 +311,7 @@ public class TransactionProcessorTest {
       // read all back
       scan = new Scan(row);
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
+        TxUtils.createDummyTransaction(txVisibilityState), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       regionScanner = region.getScanner(scan);
       results = Lists.newArrayList();
       assertFalse(regionScanner.next(results));
@@ -329,7 +333,7 @@ public class TransactionProcessorTest {
 
       scan = new Scan(row);
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
+        TxUtils.createDummyTransaction(txVisibilityState), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       regionScanner = region.getScanner(scan);
       results = Lists.newArrayList();
       assertFalse(regionScanner.next(results));
@@ -415,7 +419,7 @@ public class TransactionProcessorTest {
       scan = new Scan();
       scan.setMaxVersions();
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
+        TxUtils.createDummyTransaction(txVisibilityState), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       scanner = region.getScanner(scan);
       results = Lists.newArrayList();
       scanner.next(results);
@@ -470,7 +474,7 @@ public class TransactionProcessorTest {
     cache.setConf(conf);
     cache.startAndWait();
     // verify that the transaction snapshot read matches what we wrote in setupBeforeClass()
-    TransactionSnapshot cachedSnapshot = cache.getLatestState();
+    TransactionVisibilityState cachedSnapshot = cache.getLatestState();
     assertNotNull(cachedSnapshot);
     assertEquals(invalidSet, cachedSnapshot.getInvalid());
     cache.stopAndWait();
@@ -481,8 +485,7 @@ public class TransactionProcessorTest {
     private final ZooKeeperWatcher zookeeper;
     private final Map<String, HRegion> regions = new HashMap<String, HRegion>();
     private boolean stopping = false;
-    private final ConcurrentSkipListMap<byte[], Boolean> rit =
-      new ConcurrentSkipListMap<byte[], Boolean>(Bytes.BYTES_COMPARATOR);
+    private final ConcurrentSkipListMap<byte[], Boolean> rit = new ConcurrentSkipListMap<>(Bytes.BYTES_COMPARATOR);
     private HFileSystem hfs = null;
     private ServerName serverName = null;
     private RpcServerInterface rpcServer = null;

--- a/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessor.java
@@ -22,7 +22,7 @@ import co.cask.tephra.TxConstants;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.hbase98.Filters;
-import co.cask.tephra.persist.TransactionSnapshot;
+import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.util.TxUtils;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
@@ -263,7 +263,7 @@ public class TransactionProcessor extends BaseRegionObserver {
   }
 
   protected InternalScanner createStoreScanner(RegionCoprocessorEnvironment env, String action,
-                                               TransactionSnapshot snapshot, Store store,
+                                               TransactionVisibilityState snapshot, Store store,
                                                List<? extends KeyValueScanner> scanners, ScanType type,
                                                long earliestPutTs) throws IOException {
     if (snapshot == null) {

--- a/tephra-hbase-compat-1.0-cdh/src/main/java/co/cask/tephra/hbase10cdh/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.0-cdh/src/main/java/co/cask/tephra/hbase10cdh/coprocessor/TransactionProcessor.java
@@ -22,7 +22,7 @@ import co.cask.tephra.TxConstants;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.hbase10cdh.Filters;
-import co.cask.tephra.persist.TransactionSnapshot;
+import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.util.TxUtils;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
@@ -263,7 +263,7 @@ public class TransactionProcessor extends BaseRegionObserver {
   }
 
   protected InternalScanner createStoreScanner(RegionCoprocessorEnvironment env, String action,
-                                               TransactionSnapshot snapshot, Store store,
+                                               TransactionVisibilityState snapshot, Store store,
                                                List<? extends KeyValueScanner> scanners, ScanType type,
                                                long earliestPutTs) throws IOException {
     if (snapshot == null) {

--- a/tephra-hbase-compat-1.0-cdh/src/test/java/co/cask/tephra/hbase10cdh/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-1.0-cdh/src/test/java/co/cask/tephra/hbase10cdh/coprocessor/TransactionProcessorTest.java
@@ -25,6 +25,7 @@ import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.HDFSTransactionStateStorage;
 import co.cask.tephra.persist.TransactionSnapshot;
+import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.snapshot.DefaultSnapshotCodec;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
 import co.cask.tephra.util.TxUtils;
@@ -98,7 +99,7 @@ public class TransactionProcessorTest {
   private static MiniDFSCluster dfsCluster;
   private static Configuration conf;
   private static LongArrayList invalidSet = new LongArrayList(new long[]{V[3], V[5], V[7]});
-  private static TransactionSnapshot txSnapshot;
+  private static TransactionVisibilityState txVisibilityState;
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
@@ -116,12 +117,15 @@ public class TransactionProcessorTest {
     conf.set(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES, DefaultSnapshotCodec.class.getName());
 
     // write an initial transaction snapshot
-    txSnapshot = TransactionSnapshot.copyFrom(
-        System.currentTimeMillis(), V[6] - 1, V[7], invalidSet,
-        // this will set visibility upper bound to V[6]
-        Maps.newTreeMap(ImmutableSortedMap.of(V[6], new TransactionManager.InProgressTx(V[6] - 1, Long.MAX_VALUE,
-                                                                                        TransactionType.SHORT))),
-        new HashMap<Long, Set<ChangeId>>(), new TreeMap<Long, Set<ChangeId>>());
+    TransactionSnapshot txSnapshot = TransactionSnapshot.copyFrom(
+      System.currentTimeMillis(), V[6] - 1, V[7], invalidSet,
+      // this will set visibility upper bound to V[6]
+      Maps.newTreeMap(ImmutableSortedMap.of(V[6], new TransactionManager.InProgressTx(V[6] - 1, Long.MAX_VALUE,
+                                                                                      TransactionType.SHORT))),
+      new HashMap<Long, Set<ChangeId>>(), new TreeMap<Long, Set<ChangeId>>());
+    txVisibilityState = new TransactionSnapshot(txSnapshot.getTimestamp(), txSnapshot.getReadPointer(),
+                                                txSnapshot.getWritePointer(), txSnapshot.getInvalid(),
+                                                txSnapshot.getInProgress());
     HDFSTransactionStateStorage tmpStorage =
       new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf), new TxMetricsCollector());
     tmpStorage.startAndWait();
@@ -233,8 +237,8 @@ public class TransactionProcessorTest {
       // should be only one row
       assertFalse(regionScanner.next(results));
       assertKeyValueMatches(results, 1,
-          new long[]{V[8], V[6], deleteTs},
-          new byte[][]{Bytes.toBytes(V[8]), Bytes.toBytes(V[6]), new byte[0]});
+                            new long[]{V[8], V[6], deleteTs},
+                            new byte[][]{Bytes.toBytes(V[8]), Bytes.toBytes(V[6]), new byte[0]});
     } finally {
       region.close();
     }
@@ -249,7 +253,7 @@ public class TransactionProcessorTest {
       region.initialize();
 
       // all puts use a timestamp before the tx snapshot's visibility upper bound, making them eligible for removal
-      long writeTs = txSnapshot.getVisibilityUpperBound() - 10;
+      long writeTs = txVisibilityState.getVisibilityUpperBound() - 10;
       // deletes are performed after the writes, but still before the visibility upper bound
       long deleteTs = writeTs + 1;
       // write separate columns to confirm that delete markers survive across flushes
@@ -292,7 +296,7 @@ public class TransactionProcessorTest {
       // read all back
       scan = new Scan(row);
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
+        TxUtils.createDummyTransaction(txVisibilityState), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       regionScanner = region.getScanner(scan);
       results = Lists.newArrayList();
       assertFalse(regionScanner.next(results));
@@ -314,7 +318,7 @@ public class TransactionProcessorTest {
 
       scan = new Scan(row);
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
+        TxUtils.createDummyTransaction(txVisibilityState), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       regionScanner = region.getScanner(scan);
       results = Lists.newArrayList();
       assertFalse(regionScanner.next(results));
@@ -400,7 +404,7 @@ public class TransactionProcessorTest {
       scan = new Scan();
       scan.setMaxVersions();
       scan.setFilter(new TransactionVisibilityFilter(
-          TxUtils.createDummyTransaction(txSnapshot), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
+        TxUtils.createDummyTransaction(txVisibilityState), new TreeMap<byte[], Long>(), false, ScanType.USER_SCAN));
       scanner = region.getScanner(scan);
       results = Lists.newArrayList();
       scanner.next(results);
@@ -428,8 +432,8 @@ public class TransactionProcessorTest {
     HRegionInfo regionInfo = new HRegionInfo(TableName.valueOf(tableName));
     HRegionFileSystem regionFS = HRegionFileSystem.createRegionOnFileSystem(conf, fs, tablePath, regionInfo);
     return new HRegion(regionFS, hLog, conf, htd,
-        new LocalRegionServerServices(conf, ServerName.valueOf(
-            InetAddress.getLocalHost().getHostName(), 0, System.currentTimeMillis())));
+                       new LocalRegionServerServices(conf, ServerName.valueOf(
+                         InetAddress.getLocalHost().getHostName(), 0, System.currentTimeMillis())));
   }
 
   private void assertKeyValueMatches(List<Cell> results, int index, long[] versions) {
@@ -457,7 +461,7 @@ public class TransactionProcessorTest {
     cache.setConf(conf);
     cache.startAndWait();
     // verify that the transaction snapshot read matches what we wrote in setupBeforeClass()
-    TransactionSnapshot cachedSnapshot = cache.getLatestState();
+    TransactionVisibilityState cachedSnapshot = cache.getLatestState();
     assertNotNull(cachedSnapshot);
     assertEquals(invalidSet, cachedSnapshot.getInvalid());
     cache.stopAndWait();

--- a/tephra-hbase-compat-1.0/src/main/java/co/cask/tephra/hbase10/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.0/src/main/java/co/cask/tephra/hbase10/coprocessor/TransactionProcessor.java
@@ -22,7 +22,7 @@ import co.cask.tephra.TxConstants;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.hbase10.Filters;
-import co.cask.tephra.persist.TransactionSnapshot;
+import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.util.TxUtils;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
@@ -263,7 +263,7 @@ public class TransactionProcessor extends BaseRegionObserver {
   }
 
   protected InternalScanner createStoreScanner(RegionCoprocessorEnvironment env, String action,
-                                               TransactionSnapshot snapshot, Store store,
+                                               TransactionVisibilityState snapshot, Store store,
                                                List<? extends KeyValueScanner> scanners, ScanType type,
                                                long earliestPutTs) throws IOException {
     if (snapshot == null) {

--- a/tephra-hbase-compat-1.1/src/main/java/co/cask/tephra/hbase11/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.1/src/main/java/co/cask/tephra/hbase11/coprocessor/TransactionProcessor.java
@@ -22,7 +22,7 @@ import co.cask.tephra.TxConstants;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.hbase11.Filters;
-import co.cask.tephra.persist.TransactionSnapshot;
+import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.util.TxUtils;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
@@ -262,7 +262,7 @@ public class TransactionProcessor extends BaseRegionObserver {
   }
 
   protected InternalScanner createStoreScanner(RegionCoprocessorEnvironment env, String action,
-                                               TransactionSnapshot snapshot, Store store,
+                                               TransactionVisibilityState snapshot, Store store,
                                                List<? extends KeyValueScanner> scanners, ScanType type,
                                                long earliestPutTs) throws IOException {
     if (snapshot == null) {


### PR DESCRIPTION
Complete TransactionSnapshot need not be decoded in Coprocessor's TransactionStateCache. Instead decode only the minimal information that is required avoiding the bulk of transaction snapshot state ie, change sets of committing and committed transactions.

JIRA: https://issues.cask.co/browse/TEPHRA-113

