### PR TITLE
TEPHRA-135 Delete should preserve attributes

### DIFF
--- a/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/TransactionAwareHTable.java
@@ -19,8 +19,10 @@ import co.cask.tephra.AbstractTransactionAwareTable;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TxConstants;
+
 import com.google.protobuf.Service;
 import com.google.protobuf.ServiceException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -584,6 +586,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
         }
       }
     }
+    for (Map.Entry<String, byte[]> entry : delete.getAttributesMap().entrySet()) {
+        txDelete.setAttribute(entry.getKey(), entry.getValue());
+    }
+    txDelete.setWriteToWAL(delete.getWriteToWAL());
     return txDelete;
   }
 

--- a/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/coprocessor/TransactionProcessor.java
@@ -24,9 +24,11 @@ import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.hbase96.Filters;
 import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.util.TxUtils;
+
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
@@ -192,6 +194,9 @@ public class TransactionProcessor extends BaseRegionObserver {
                   HConstants.EMPTY_BYTE_ARRAY);
         }
       }
+    }
+    for (Map.Entry<String, byte[]> entry : delete.getAttributesMap().entrySet()) {
+        deleteMarkers.setAttribute(entry.getKey(), entry.getValue());
     }
     e.getEnvironment().getRegion().put(deleteMarkers);
     // skip normal delete handling

--- a/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/TransactionAwareHTable.java
@@ -19,10 +19,12 @@ import co.cask.tephra.AbstractTransactionAwareTable;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TxConstants;
+
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Message;
 import com.google.protobuf.Service;
 import com.google.protobuf.ServiceException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -611,6 +613,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
         }
       }
     }
+    for (Map.Entry<String, byte[]> entry : delete.getAttributesMap().entrySet()) {
+        txDelete.setAttribute(entry.getKey(), entry.getValue());
+    }
+    txDelete.setWriteToWAL(delete.getWriteToWAL());
     return txDelete;
   }
 

--- a/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/coprocessor/TransactionProcessor.java
@@ -24,9 +24,11 @@ import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.hbase98.Filters;
 import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.util.TxUtils;
+
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
@@ -192,6 +194,9 @@ public class TransactionProcessor extends BaseRegionObserver {
                   HConstants.EMPTY_BYTE_ARRAY);
         }
       }
+    }
+    for (Map.Entry<String, byte[]> entry : delete.getAttributesMap().entrySet()) {
+        deleteMarkers.setAttribute(entry.getKey(), entry.getValue());
     }
     e.getEnvironment().getRegion().put(deleteMarkers);
     // skip normal delete handling

--- a/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/TransactionAwareHTableTest.java
@@ -26,11 +26,15 @@ import co.cask.tephra.inmemory.InMemoryTxSystemClient;
 import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.InMemoryTransactionStateStorage;
 import co.cask.tephra.persist.TransactionStateStorage;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
@@ -38,6 +42,7 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
@@ -46,6 +51,10 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -59,6 +68,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +112,28 @@ public class TransactionAwareHTableTest {
     private static final byte[] value3 = Bytes.toBytes("value3");
   }
 
+  private static final String TEST_ATTRIBUTE = "TEST_ATTRIBUTE";
+  
+  public static class TestRegionObserver extends BaseRegionObserver {
+      @Override
+      public void prePut(final ObserverContext<RegionCoprocessorEnvironment> c,
+          final Put put, final WALEdit edit,
+          final Durability durability) throws IOException {
+          if (put.getAttribute(TEST_ATTRIBUTE) == null) {
+              throw new DoNotRetryIOException("Put should preserve attributes");
+          }
+      }
+            
+      @Override
+      public void preDelete(final ObserverContext<RegionCoprocessorEnvironment> c,
+          final Delete delete, final WALEdit edit,
+          final Durability durability) throws IOException {
+          if (delete.getAttribute(TEST_ATTRIBUTE) == null) {
+              throw new DoNotRetryIOException("Delete should preserve attributes");
+          }
+      }
+  }
+  
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
     testUtil = new HBaseTestingUtility();
@@ -146,10 +178,11 @@ public class TransactionAwareHTableTest {
   }
 
   private HTable createTable(byte[] tableName, byte[][] columnFamilies) throws Exception {
-    return createTable(tableName, columnFamilies, false);
+    return createTable(tableName, columnFamilies, false, Collections.<String>emptyList());
   }
 
-  private HTable createTable(byte[] tableName, byte[][] columnFamilies, boolean existingData) throws Exception {
+  private HTable createTable(byte[] tableName, byte[][] columnFamilies, boolean existingData, 
+    List<String> coprocessors) throws Exception {
     HTableDescriptor desc = new HTableDescriptor(TableName.valueOf(tableName));
     for (byte[] family : columnFamilies) {
       HColumnDescriptor columnDesc = new HColumnDescriptor(family);
@@ -160,11 +193,17 @@ public class TransactionAwareHTableTest {
     if (existingData) {
       desc.setValue(TxConstants.READ_NON_TX_DATA, "true");
     }
-    desc.addCoprocessor(TransactionProcessor.class.getName());
+    // Divide individually to prevent any overflow
+    int priority  = Coprocessor.PRIORITY_USER; 
+    desc.addCoprocessor(TransactionProcessor.class.getName(), null, priority, null);
+    // order in list is the same order that coprocessors will be invoked  
+    for (String coprocessor : coprocessors) {
+      desc.addCoprocessor(coprocessor, null, ++priority, null);
+    }
     hBaseAdmin.createTable(desc);
     testUtil.waitTableAvailable(tableName, 5000);
     return new HTable(testUtil.getConfiguration(), tableName);
-  }
+   }
 
   /**
    * Test transactional put and get requests.
@@ -352,6 +391,53 @@ public class TransactionAwareHTableTest {
       hTable.close();
     }
   }
+  
+  /**
+   * Test that put and delete attributes are preserved
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testAttributesPreserved() throws Exception {
+    HTable hTable = createTable(Bytes.toBytes("TestAttributesPreserved"),
+        new byte[][]{TestBytes.family, TestBytes.family2}, false,
+        Lists.newArrayList(TestRegionObserver.class.getName()));
+    try {
+      TransactionAwareHTable txTable = new TransactionAwareHTable(hTable);
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+
+      txContext.start();
+      Put put = new Put(TestBytes.row);
+      put.add(TestBytes.family, TestBytes.qualifier, TestBytes.value);
+      put.add(TestBytes.family2, TestBytes.qualifier, TestBytes.value2);
+      // set an attribute on the put, TestRegionObserver will verify it still exists
+      put.setAttribute(TEST_ATTRIBUTE, new byte[]{});
+      txTable.put(put);
+      txContext.finish();
+
+      txContext.start();
+      Result result = txTable.get(new Get(TestBytes.row));
+      txContext.finish();
+      byte[] value = result.getValue(TestBytes.family, TestBytes.qualifier);
+      assertArrayEquals(TestBytes.value, value);
+      value = result.getValue(TestBytes.family2, TestBytes.qualifier);
+      assertArrayEquals(TestBytes.value2, value);
+
+      // test full row delete, TestRegionObserver will verify it still exists
+      txContext.start();
+      Delete delete = new Delete(TestBytes.row);
+      delete.setAttribute(TEST_ATTRIBUTE, new byte[]{});
+      txTable.delete(delete);
+      txContext.finish();
+
+      txContext.start();
+      result = txTable.get(new Get(TestBytes.row));
+      txContext.finish();
+      assertTrue(result.isEmpty());
+    } finally {
+        hTable.close();
+      }
+    }
 
   /**
    * Test aborted transactional delete requests, that must be rolled back.
@@ -1028,7 +1114,8 @@ public class TransactionAwareHTableTest {
     byte[] val111 = Bytes.toBytes("val111");
 
     TransactionAwareHTable txTable =
-      new TransactionAwareHTable(createTable(Bytes.toBytes("testExistingData"), new byte[][]{TestBytes.family}, true));
+      new TransactionAwareHTable(createTable(Bytes.toBytes("testExistingData"), new byte[][]{TestBytes.family}, true, 
+      Collections.<String>emptyList()));
     TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
 
     // Add some pre-existing, non-transactional data
@@ -1178,7 +1265,7 @@ public class TransactionAwareHTableTest {
   @Test
   public void testVisibilityAll() throws Exception {
     HTable nonTxTable = createTable(Bytes.toBytes("testVisibilityAll"),
-                                           new byte[][]{TestBytes.family, TestBytes.family2}, true);
+      new byte[][]{TestBytes.family, TestBytes.family2}, true, Collections.<String>emptyList());
     TransactionAwareHTable txTable =
       new TransactionAwareHTable(nonTxTable,
                                  TxConstants.ConflictDetection.ROW); // ROW conflict detection to verify family deletes

--- a/tephra-hbase-compat-1.0-cdh/src/main/java/co/cask/tephra/hbase10cdh/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.0-cdh/src/main/java/co/cask/tephra/hbase10cdh/TransactionAwareHTable.java
@@ -19,10 +19,12 @@ import co.cask.tephra.AbstractTransactionAwareTable;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TxConstants;
+
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Message;
 import com.google.protobuf.Service;
 import com.google.protobuf.ServiceException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -643,6 +645,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
         }
       }
     }
+    for (Map.Entry<String, byte[]> entry : delete.getAttributesMap().entrySet()) {
+        txDelete.setAttribute(entry.getKey(), entry.getValue());
+    }
+    txDelete.setWriteToWAL(delete.getWriteToWAL());
     return txDelete;
   }
 

--- a/tephra-hbase-compat-1.0-cdh/src/main/java/co/cask/tephra/hbase10cdh/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.0-cdh/src/main/java/co/cask/tephra/hbase10cdh/coprocessor/TransactionProcessor.java
@@ -24,9 +24,11 @@ import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.hbase10cdh.Filters;
 import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.util.TxUtils;
+
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
@@ -192,6 +194,9 @@ public class TransactionProcessor extends BaseRegionObserver {
                   HConstants.EMPTY_BYTE_ARRAY);
         }
       }
+    }
+    for (Map.Entry<String, byte[]> entry : delete.getAttributesMap().entrySet()) {
+        deleteMarkers.setAttribute(entry.getKey(), entry.getValue());
     }
     e.getEnvironment().getRegion().put(deleteMarkers);
     // skip normal delete handling

--- a/tephra-hbase-compat-1.0-cdh/src/test/java/co/cask/tephra/hbase10cdh/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.0-cdh/src/test/java/co/cask/tephra/hbase10cdh/TransactionAwareHTableTest.java
@@ -26,11 +26,15 @@ import co.cask.tephra.inmemory.InMemoryTxSystemClient;
 import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.InMemoryTransactionStateStorage;
 import co.cask.tephra.persist.TransactionStateStorage;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
@@ -38,6 +42,7 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
@@ -46,6 +51,10 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -59,6 +68,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +112,28 @@ public class TransactionAwareHTableTest {
     private static final byte[] value3 = Bytes.toBytes("value3");
   }
 
+  private static final String TEST_ATTRIBUTE = "TEST_ATTRIBUTE";
+  
+  public static class TestRegionObserver extends BaseRegionObserver {
+      @Override
+      public void prePut(final ObserverContext<RegionCoprocessorEnvironment> c,
+          final Put put, final WALEdit edit,
+          final Durability durability) throws IOException {
+          if (put.getAttribute(TEST_ATTRIBUTE) == null) {
+              throw new DoNotRetryIOException("Put should preserve attributes");
+          }
+      }
+            
+      @Override
+      public void preDelete(final ObserverContext<RegionCoprocessorEnvironment> c,
+          final Delete delete, final WALEdit edit,
+          final Durability durability) throws IOException {
+          if (delete.getAttribute(TEST_ATTRIBUTE) == null) {
+              throw new DoNotRetryIOException("Delete should preserve attributes");
+          }
+      }
+  }
+  
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
     testUtil = new HBaseTestingUtility();
@@ -146,10 +178,11 @@ public class TransactionAwareHTableTest {
   }
 
   private HTable createTable(byte[] tableName, byte[][] columnFamilies) throws Exception {
-    return createTable(tableName, columnFamilies, false);
+    return createTable(tableName, columnFamilies, false, Collections.<String>emptyList());
   }
 
-  private HTable createTable(byte[] tableName, byte[][] columnFamilies, boolean existingData) throws Exception {
+  private HTable createTable(byte[] tableName, byte[][] columnFamilies, boolean existingData, 
+    List<String> coprocessors) throws Exception {
     HTableDescriptor desc = new HTableDescriptor(TableName.valueOf(tableName));
     for (byte[] family : columnFamilies) {
       HColumnDescriptor columnDesc = new HColumnDescriptor(family);
@@ -160,11 +193,17 @@ public class TransactionAwareHTableTest {
     if (existingData) {
       desc.setValue(TxConstants.READ_NON_TX_DATA, "true");
     }
-    desc.addCoprocessor(TransactionProcessor.class.getName());
+    // Divide individually to prevent any overflow
+    int priority  = Coprocessor.PRIORITY_USER; 
+    desc.addCoprocessor(TransactionProcessor.class.getName(), null, priority, null);
+    // order in list is the same order that coprocessors will be invoked  
+    for (String coprocessor : coprocessors) {
+      desc.addCoprocessor(coprocessor, null, ++priority, null);
+    }
     hBaseAdmin.createTable(desc);
     testUtil.waitTableAvailable(tableName, 5000);
     return new HTable(testUtil.getConfiguration(), tableName);
-  }
+   }
 
   /**
    * Test transactional put and get requests.
@@ -353,6 +392,53 @@ public class TransactionAwareHTableTest {
     }
   }
 
+  /**
+   * Test that put and delete attributes are preserved
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testAttributesPreserved() throws Exception {
+    HTable hTable = createTable(Bytes.toBytes("TestAttributesPreserved"),
+        new byte[][]{TestBytes.family, TestBytes.family2}, false,
+        Lists.newArrayList(TestRegionObserver.class.getName()));
+    try {
+      TransactionAwareHTable txTable = new TransactionAwareHTable(hTable);
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+
+      txContext.start();
+      Put put = new Put(TestBytes.row);
+      put.add(TestBytes.family, TestBytes.qualifier, TestBytes.value);
+      put.add(TestBytes.family2, TestBytes.qualifier, TestBytes.value2);
+      // set an attribute on the put, TestRegionObserver will verify it still exists
+      put.setAttribute(TEST_ATTRIBUTE, new byte[]{});
+      txTable.put(put);
+      txContext.finish();
+
+      txContext.start();
+      Result result = txTable.get(new Get(TestBytes.row));
+      txContext.finish();
+      byte[] value = result.getValue(TestBytes.family, TestBytes.qualifier);
+      assertArrayEquals(TestBytes.value, value);
+      value = result.getValue(TestBytes.family2, TestBytes.qualifier);
+      assertArrayEquals(TestBytes.value2, value);
+
+      // test full row delete, TestRegionObserver will verify it still exists
+      txContext.start();
+      Delete delete = new Delete(TestBytes.row);
+      delete.setAttribute(TEST_ATTRIBUTE, new byte[]{});
+      txTable.delete(delete);
+      txContext.finish();
+
+      txContext.start();
+      result = txTable.get(new Get(TestBytes.row));
+      txContext.finish();
+      assertTrue(result.isEmpty());
+    } finally {
+        hTable.close();
+      }
+    }
+  
   /**
    * Test aborted transactional delete requests, that must be rolled back.
    *
@@ -1028,7 +1114,8 @@ public class TransactionAwareHTableTest {
     byte[] val111 = Bytes.toBytes("val111");
 
     TransactionAwareHTable txTable =
-      new TransactionAwareHTable(createTable(Bytes.toBytes("testExistingData"), new byte[][]{TestBytes.family}, true));
+      new TransactionAwareHTable(createTable(Bytes.toBytes("testExistingData"), new byte[][]{TestBytes.family}, true, 
+      Collections.<String>emptyList()));
     TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
 
     // Add some pre-existing, non-transactional data
@@ -1178,7 +1265,7 @@ public class TransactionAwareHTableTest {
   @Test
   public void testVisibilityAll() throws Exception {
     HTable nonTxTable = createTable(Bytes.toBytes("testVisibilityAll"),
-                                    new byte[][]{TestBytes.family, TestBytes.family2}, true);
+      new byte[][]{TestBytes.family, TestBytes.family2}, true, Collections.<String>emptyList());
     TransactionAwareHTable txTable =
       new TransactionAwareHTable(nonTxTable,
                                  TxConstants.ConflictDetection.ROW); // ROW conflict detection to verify family deletes

--- a/tephra-hbase-compat-1.0/src/main/java/co/cask/tephra/hbase10/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.0/src/main/java/co/cask/tephra/hbase10/TransactionAwareHTable.java
@@ -643,6 +643,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
         }
       }
     }
+    for (Map.Entry<String, byte[]> entry : delete.getAttributesMap().entrySet()) {
+        txDelete.setAttribute(entry.getKey(), entry.getValue());
+    }
+    txDelete.setWriteToWAL(delete.getWriteToWAL());
     return txDelete;
   }
 

--- a/tephra-hbase-compat-1.0/src/main/java/co/cask/tephra/hbase10/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.0/src/main/java/co/cask/tephra/hbase10/coprocessor/TransactionProcessor.java
@@ -24,9 +24,11 @@ import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.hbase10.Filters;
 import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.util.TxUtils;
+
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
@@ -192,6 +194,9 @@ public class TransactionProcessor extends BaseRegionObserver {
                   HConstants.EMPTY_BYTE_ARRAY);
         }
       }
+    }
+    for (Map.Entry<String, byte[]> entry : delete.getAttributesMap().entrySet()) {
+        deleteMarkers.setAttribute(entry.getKey(), entry.getValue());
     }
     e.getEnvironment().getRegion().put(deleteMarkers);
     // skip normal delete handling

--- a/tephra-hbase-compat-1.0/src/test/java/co/cask/tephra/hbase10/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.0/src/test/java/co/cask/tephra/hbase10/TransactionAwareHTableTest.java
@@ -26,11 +26,15 @@ import co.cask.tephra.inmemory.InMemoryTxSystemClient;
 import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.InMemoryTransactionStateStorage;
 import co.cask.tephra.persist.TransactionStateStorage;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
@@ -38,6 +42,7 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
@@ -46,6 +51,10 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -59,6 +68,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +110,28 @@ public class TransactionAwareHTableTest {
     private static final byte[] value = Bytes.toBytes("value");
     private static final byte[] value2 = Bytes.toBytes("value2");
     private static final byte[] value3 = Bytes.toBytes("value3");
+  }
+  
+  private static final String TEST_ATTRIBUTE = "TEST_ATTRIBUTE";
+  
+  public static class TestRegionObserver extends BaseRegionObserver {
+      @Override
+      public void prePut(final ObserverContext<RegionCoprocessorEnvironment> c,
+          final Put put, final WALEdit edit,
+          final Durability durability) throws IOException {
+          if (put.getAttribute(TEST_ATTRIBUTE) == null) {
+              throw new DoNotRetryIOException("Put should preserve attributes");
+          }
+      }
+            
+      @Override
+      public void preDelete(final ObserverContext<RegionCoprocessorEnvironment> c,
+          final Delete delete, final WALEdit edit,
+          final Durability durability) throws IOException {
+          if (delete.getAttribute(TEST_ATTRIBUTE) == null) {
+              throw new DoNotRetryIOException("Delete should preserve attributes");
+          }
+      }
   }
 
   @BeforeClass
@@ -144,12 +176,13 @@ public class TransactionAwareHTableTest {
     hBaseAdmin.disableTable(TestBytes.table);
     hBaseAdmin.deleteTable(TestBytes.table);
   }
-
+  
   private HTable createTable(byte[] tableName, byte[][] columnFamilies) throws Exception {
-    return createTable(tableName, columnFamilies, false);
+    return createTable(tableName, columnFamilies, false, Collections.<String>emptyList());
   }
 
-  private HTable createTable(byte[] tableName, byte[][] columnFamilies, boolean existingData) throws Exception {
+  private HTable createTable(byte[] tableName, byte[][] columnFamilies, boolean existingData, 
+    List<String> coprocessors) throws Exception {
     HTableDescriptor desc = new HTableDescriptor(TableName.valueOf(tableName));
     for (byte[] family : columnFamilies) {
       HColumnDescriptor columnDesc = new HColumnDescriptor(family);
@@ -160,7 +193,13 @@ public class TransactionAwareHTableTest {
     if (existingData) {
       desc.setValue(TxConstants.READ_NON_TX_DATA, "true");
     }
-    desc.addCoprocessor(TransactionProcessor.class.getName());
+    // Divide individually to prevent any overflow
+    int priority  = Coprocessor.PRIORITY_USER; 
+    desc.addCoprocessor(TransactionProcessor.class.getName(), null, priority, null);
+    // order in list is the same order that coprocessors will be invoked  
+    for (String coprocessor : coprocessors) {
+      desc.addCoprocessor(coprocessor, null, ++priority, null);
+    }
     hBaseAdmin.createTable(desc);
     testUtil.waitTableAvailable(tableName, 5000);
     return new HTable(testUtil.getConfiguration(), tableName);
@@ -353,6 +392,53 @@ public class TransactionAwareHTableTest {
     }
   }
 
+  /**
+   * Test that put and delete attributes are preserved
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testAttributesPreserved() throws Exception {
+    HTable hTable = createTable(Bytes.toBytes("TestAttributesPreserved"),
+        new byte[][]{TestBytes.family, TestBytes.family2}, false,
+        Lists.newArrayList(TestRegionObserver.class.getName()));
+    try {
+      TransactionAwareHTable txTable = new TransactionAwareHTable(hTable);
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+
+      txContext.start();
+      Put put = new Put(TestBytes.row);
+      put.add(TestBytes.family, TestBytes.qualifier, TestBytes.value);
+      put.add(TestBytes.family2, TestBytes.qualifier, TestBytes.value2);
+      // set an attribute on the put, TestRegionObserver will verify it still exists
+      put.setAttribute(TEST_ATTRIBUTE, new byte[]{});
+      txTable.put(put);
+      txContext.finish();
+
+      txContext.start();
+      Result result = txTable.get(new Get(TestBytes.row));
+      txContext.finish();
+      byte[] value = result.getValue(TestBytes.family, TestBytes.qualifier);
+      assertArrayEquals(TestBytes.value, value);
+      value = result.getValue(TestBytes.family2, TestBytes.qualifier);
+      assertArrayEquals(TestBytes.value2, value);
+
+      // test full row delete, TestRegionObserver will verify it still exists
+      txContext.start();
+      Delete delete = new Delete(TestBytes.row);
+      delete.setAttribute(TEST_ATTRIBUTE, new byte[]{});
+      txTable.delete(delete);
+      txContext.finish();
+
+      txContext.start();
+      result = txTable.get(new Get(TestBytes.row));
+      txContext.finish();
+      assertTrue(result.isEmpty());
+    } finally {
+        hTable.close();
+      }
+    }
+  
   /**
    * Test aborted transactional delete requests, that must be rolled back.
    *
@@ -1028,7 +1114,8 @@ public class TransactionAwareHTableTest {
     byte[] val111 = Bytes.toBytes("val111");
 
     TransactionAwareHTable txTable =
-      new TransactionAwareHTable(createTable(Bytes.toBytes("testExistingData"), new byte[][]{TestBytes.family}, true));
+      new TransactionAwareHTable(createTable(Bytes.toBytes("testExistingData"), new byte[][]{TestBytes.family}, true, 
+      Collections.<String>emptyList()));
     TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
 
     // Add some pre-existing, non-transactional data
@@ -1178,7 +1265,7 @@ public class TransactionAwareHTableTest {
   @Test
   public void testVisibilityAll() throws Exception {
     HTable nonTxTable = createTable(Bytes.toBytes("testVisibilityAll"),
-                                    new byte[][]{TestBytes.family, TestBytes.family2}, true);
+      new byte[][]{TestBytes.family, TestBytes.family2}, true, Collections.<String>emptyList());
     TransactionAwareHTable txTable =
       new TransactionAwareHTable(nonTxTable,
                                  TxConstants.ConflictDetection.ROW); // ROW conflict detection to verify family deletes

--- a/tephra-hbase-compat-1.1/src/main/java/co/cask/tephra/hbase11/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.1/src/main/java/co/cask/tephra/hbase11/TransactionAwareHTable.java
@@ -19,10 +19,12 @@ import co.cask.tephra.AbstractTransactionAwareTable;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TxConstants;
+
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Message;
 import com.google.protobuf.Service;
 import com.google.protobuf.ServiceException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -643,6 +645,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
         }
       }
     }
+    for (Map.Entry<String, byte[]> entry : delete.getAttributesMap().entrySet()) {
+        txDelete.setAttribute(entry.getKey(), entry.getValue());
+    }
+    txDelete.setWriteToWAL(delete.getWriteToWAL());
     return txDelete;
   }
 

--- a/tephra-hbase-compat-1.1/src/main/java/co/cask/tephra/hbase11/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.1/src/main/java/co/cask/tephra/hbase11/coprocessor/TransactionProcessor.java
@@ -24,9 +24,11 @@ import co.cask.tephra.coprocessor.TransactionStateCacheSupplier;
 import co.cask.tephra.hbase11.Filters;
 import co.cask.tephra.persist.TransactionVisibilityState;
 import co.cask.tephra.util.TxUtils;
+
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
@@ -191,6 +193,9 @@ public class TransactionProcessor extends BaseRegionObserver {
                             HConstants.EMPTY_BYTE_ARRAY);
         }
       }
+    }
+    for (Map.Entry<String, byte[]> entry : delete.getAttributesMap().entrySet()) {
+        deleteMarkers.setAttribute(entry.getKey(), entry.getValue());
     }
     e.getEnvironment().getRegion().put(deleteMarkers);
     // skip normal delete handling

--- a/tephra-hbase-compat-1.1/src/test/java/co/cask/tephra/hbase11/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.1/src/test/java/co/cask/tephra/hbase11/TransactionAwareHTableTest.java
@@ -26,11 +26,15 @@ import co.cask.tephra.inmemory.InMemoryTxSystemClient;
 import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.persist.InMemoryTransactionStateStorage;
 import co.cask.tephra.persist.TransactionStateStorage;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
@@ -38,6 +42,7 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
@@ -46,6 +51,10 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -59,6 +68,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -101,6 +111,28 @@ public class TransactionAwareHTableTest {
     private static final byte[] value2 = Bytes.toBytes("value2");
     private static final byte[] value3 = Bytes.toBytes("value3");
   }
+  
+  private static final String TEST_ATTRIBUTE = "TEST_ATTRIBUTE";
+  
+  public static class TestRegionObserver extends BaseRegionObserver {
+      @Override
+      public void prePut(final ObserverContext<RegionCoprocessorEnvironment> c,
+          final Put put, final WALEdit edit,
+          final Durability durability) throws IOException {
+          if (put.getAttribute(TEST_ATTRIBUTE) == null) {
+              throw new DoNotRetryIOException("Put should preserve attributes");
+          }
+      }
+            
+      @Override
+      public void preDelete(final ObserverContext<RegionCoprocessorEnvironment> c,
+          final Delete delete, final WALEdit edit,
+          final Durability durability) throws IOException {
+          if (delete.getAttribute(TEST_ATTRIBUTE) == null) {
+              throw new DoNotRetryIOException("Delete should preserve attributes");
+          }
+      }
+  }  
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
@@ -146,10 +178,11 @@ public class TransactionAwareHTableTest {
   }
 
   private HTable createTable(byte[] tableName, byte[][] columnFamilies) throws Exception {
-    return createTable(tableName, columnFamilies, false);
+    return createTable(tableName, columnFamilies, false, Collections.<String>emptyList());
   }
 
-  private HTable createTable(byte[] tableName, byte[][] columnFamilies, boolean existingData) throws Exception {
+  private HTable createTable(byte[] tableName, byte[][] columnFamilies, boolean existingData, 
+    List<String> coprocessors) throws Exception {
     HTableDescriptor desc = new HTableDescriptor(TableName.valueOf(tableName));
     for (byte[] family : columnFamilies) {
       HColumnDescriptor columnDesc = new HColumnDescriptor(family);
@@ -160,11 +193,17 @@ public class TransactionAwareHTableTest {
     if (existingData) {
       desc.setValue(TxConstants.READ_NON_TX_DATA, "true");
     }
-    desc.addCoprocessor(TransactionProcessor.class.getName());
+    // Divide individually to prevent any overflow
+    int priority  = Coprocessor.PRIORITY_USER; 
+    desc.addCoprocessor(TransactionProcessor.class.getName(), null, priority, null);
+    // order in list is the same order that coprocessors will be invoked  
+    for (String coprocessor : coprocessors) {
+      desc.addCoprocessor(coprocessor, null, ++priority, null);
+    }
     hBaseAdmin.createTable(desc);
     testUtil.waitTableAvailable(tableName, 5000);
     return new HTable(testUtil.getConfiguration(), tableName);
-  }
+   }
 
   /**
    * Test transactional put and get requests.
@@ -350,6 +389,53 @@ public class TransactionAwareHTableTest {
     }
   }
 
+  /**
+   * Test that put and delete attributes are preserved
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testAttributesPreserved() throws Exception {
+    HTable hTable = createTable(Bytes.toBytes("TestAttributesPreserved"),
+        new byte[][]{TestBytes.family, TestBytes.family2}, false,
+        Lists.newArrayList(TestRegionObserver.class.getName()));
+    try {
+      TransactionAwareHTable txTable = new TransactionAwareHTable(hTable);
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+
+      txContext.start();
+      Put put = new Put(TestBytes.row);
+      put.add(TestBytes.family, TestBytes.qualifier, TestBytes.value);
+      put.add(TestBytes.family2, TestBytes.qualifier, TestBytes.value2);
+      // set an attribute on the put, TestRegionObserver will verify it still exists
+      put.setAttribute(TEST_ATTRIBUTE, new byte[]{});
+      txTable.put(put);
+      txContext.finish();
+
+      txContext.start();
+      Result result = txTable.get(new Get(TestBytes.row));
+      txContext.finish();
+      byte[] value = result.getValue(TestBytes.family, TestBytes.qualifier);
+      assertArrayEquals(TestBytes.value, value);
+      value = result.getValue(TestBytes.family2, TestBytes.qualifier);
+      assertArrayEquals(TestBytes.value2, value);
+
+      // test full row delete, TestRegionObserver will verify it still exists
+      txContext.start();
+      Delete delete = new Delete(TestBytes.row);
+      delete.setAttribute(TEST_ATTRIBUTE, new byte[]{});
+      txTable.delete(delete);
+      txContext.finish();
+
+      txContext.start();
+      result = txTable.get(new Get(TestBytes.row));
+      txContext.finish();
+      assertTrue(result.isEmpty());
+    } finally {
+        hTable.close();
+      }
+    }
+  
   /**
    * Test aborted transactional delete requests, that must be rolled back.
    *
@@ -1022,7 +1108,8 @@ public class TransactionAwareHTableTest {
     byte[] val111 = Bytes.toBytes("val111");
 
     TransactionAwareHTable txTable =
-      new TransactionAwareHTable(createTable(Bytes.toBytes("testExistingData"), new byte[][]{TestBytes.family}, true));
+      new TransactionAwareHTable(createTable(Bytes.toBytes("testExistingData"), new byte[][]{TestBytes.family}, true, 
+      Collections.<String>emptyList()));
     TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
 
     // Add some pre-existing, non-transactional data
@@ -1172,7 +1259,7 @@ public class TransactionAwareHTableTest {
   @Test
   public void testVisibilityAll() throws Exception {
     HTable nonTxTable = createTable(Bytes.toBytes("testVisibilityAll"),
-                                    new byte[][]{TestBytes.family, TestBytes.family2}, true);
+      new byte[][]{TestBytes.family, TestBytes.family2}, true, Collections.<String>emptyList());
     TransactionAwareHTable txTable =
       new TransactionAwareHTable(nonTxTable,
                                  TxConstants.ConflictDetection.ROW); // ROW conflict detection to verify family deletes


### PR DESCRIPTION
@poornachandra  @JamesRTaylor

Tephra preserves attributes for Puts, but not Deletes. I modified TransactionAwareHTable.transactionalizeAction(Delete delete) and TransactionProcessor.preDelete() to preserve the Delete attributes.