### PR TITLE
TEPHRA-131 Fix rollback of family delete when ConflictDetection.ROW is used

### DIFF
--- a/tephra-core/src/main/java/co/cask/tephra/AbstractTransactionAwareTable.java
+++ b/tephra-core/src/main/java/co/cask/tephra/AbstractTransactionAwareTable.java
@@ -37,7 +37,7 @@ import java.util.TreeSet;
  */
 public abstract class AbstractTransactionAwareTable implements TransactionAware {
   protected final TransactionCodec txCodec;
-  // map of write pointers to change set assocaited with each
+  // map of write pointers to change set associated with each
   protected final Map<Long, Set<ActionChange>> changeSets;
   protected final TxConstants.ConflictDetection conflictLevel;
   protected Transaction tx;

--- a/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-0.96/src/main/java/co/cask/tephra/hbase96/TransactionAwareHTable.java
@@ -24,6 +24,7 @@ import com.google.protobuf.ServiceException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
@@ -128,7 +129,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
       for (Set<ActionChange> cs : changeSets.values()) {
         size += cs.size();
       }
-      List<Delete> rollbackDeletes = new ArrayList<Delete>(size);
+      List<Delete> rollbackDeletes = new ArrayList<>(size);
       for (Map.Entry<Long, Set<ActionChange>> entry : changeSets.entrySet()) {
         long transactionTimestamp = entry.getKey();
         for (ActionChange change : entry.getValue()) {
@@ -528,11 +529,15 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
 
     Map<byte[], List<Cell>> familyToDelete = delete.getFamilyCellMap();
     if (familyToDelete.isEmpty()) {
-      // perform a row delete is we are using row-level conflict detection
+      // perform a row delete if we are using row-level conflict detection
       if (conflictLevel == TxConstants.ConflictDetection.ROW ||
           conflictLevel == TxConstants.ConflictDetection.NONE) {
-        // no need to identify individual columns deleted
-        addToChangeSet(deleteRow, null, null);
+        // Row delete leaves delete markers in all column families of the table
+        // Therefore get all the column families of the hTable from the HTableDescriptor and add them to the changeSet
+        for (HColumnDescriptor columnDescriptor : hTable.getTableDescriptor().getColumnFamilies()) {
+          // no need to identify individual columns deleted
+          addToChangeSet(deleteRow, columnDescriptor.getName(), null);
+        }
       } else {
         Result result = get(new Get(delete.getRow()));
         // Delete everything
@@ -561,7 +566,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
             // Older versions of HBase 0.96 lack HBASE-10964, so family deletes do not correctly
             // inherit the common Delete timestamp, so must explicitly set the timestamp here.
             txDelete.deleteFamily(family, transactionTimestamp);
-            addToChangeSet(deleteRow, null, null);
+            addToChangeSet(deleteRow, family, null);
           } else {
             Result result = get(new Get(delete.getRow()).addFamily(family));
             // Delete entire family
@@ -583,7 +588,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
   }
 
   private List<? extends Row> transactionalizeActions(List<? extends Row> actions) throws IOException {
-    List<Row> transactionalizedActions = new ArrayList<Row>(actions.size());
+    List<Row> transactionalizedActions = new ArrayList<>(actions.size());
     for (Row action : actions) {
       if (action instanceof Get) {
         transactionalizedActions.add(transactionalizeAction((Get) action));

--- a/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-0.98/src/main/java/co/cask/tephra/hbase98/TransactionAwareHTable.java
@@ -26,6 +26,7 @@ import com.google.protobuf.ServiceException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
@@ -132,7 +133,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
       for (Set<ActionChange> cs : changeSets.values()) {
         size += cs.size();
       }
-      List<Delete> rollbackDeletes = new ArrayList<Delete>(size);
+      List<Delete> rollbackDeletes = new ArrayList<>(size);
       for (Map.Entry<Long, Set<ActionChange>> entry : changeSets.entrySet()) {
         long transactionTimestamp = entry.getKey();
         for (ActionChange change : entry.getValue()) {
@@ -557,11 +558,15 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
 
     Map<byte[], List<Cell>> familyToDelete = delete.getFamilyCellMap();
     if (familyToDelete.isEmpty()) {
-      // perform a row delete is we are using row-level conflict detection
+      // perform a row delete if we are using row-level conflict detection
       if (conflictLevel == TxConstants.ConflictDetection.ROW ||
           conflictLevel == TxConstants.ConflictDetection.NONE) {
-        // no need to identify individual columns deleted
-        addToChangeSet(deleteRow, null, null);
+        // Row delete leaves delete markers in all column families of the table
+        // Therefore get all the column families of the hTable from the HTableDescriptor and add them to the changeSet
+        for (HColumnDescriptor columnDescriptor : hTable.getTableDescriptor().getColumnFamilies()) {
+          // no need to identify individual columns deleted
+          addToChangeSet(deleteRow, columnDescriptor.getName(), null);
+        }
       } else {
         Result result = get(new Get(delete.getRow()));
         // Delete everything
@@ -588,7 +593,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
               conflictLevel == TxConstants.ConflictDetection.NONE) {
             // no need to identify individual columns deleted
             txDelete.deleteFamily(family);
-            addToChangeSet(deleteRow, null, null);
+            addToChangeSet(deleteRow, family, null);
           } else {
             Result result = get(new Get(delete.getRow()).addFamily(family));
             // Delete entire family
@@ -610,7 +615,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
   }
 
   private List<? extends Row> transactionalizeActions(List<? extends Row> actions) throws IOException {
-    List<Row> transactionalizedActions = new ArrayList<Row>(actions.size());
+    List<Row> transactionalizedActions = new ArrayList<>(actions.size());
     for (Row action : actions) {
       if (action instanceof Get) {
         transactionalizedActions.add(transactionalizeAction((Get) action));

--- a/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/co/cask/tephra/hbase98/TransactionAwareHTableTest.java
@@ -384,6 +384,74 @@ public class TransactionAwareHTableTest {
     assertArrayEquals(TestBytes.value, value);
   }
 
+  private void testDeleteRollback(TxConstants.ConflictDetection conflictDetection) throws Exception {
+    String tableName = String.format("%s%s", "TestColFamilyDelete", conflictDetection);
+    HTable hTable = createTable(Bytes.toBytes(tableName), new byte[][]{TestBytes.family});
+    try (TransactionAwareHTable txTable = new TransactionAwareHTable(hTable, conflictDetection)) {
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+      txContext.start();
+      txTable.put(new Put(TestBytes.row).add(TestBytes.family, TestBytes.qualifier, TestBytes.value));
+      txContext.finish();
+
+      // Start a tx, delete the row and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row));
+      txContext.abort();
+
+      // Start a tx, delete a column family and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row).deleteFamily(TestBytes.family));
+      txContext.abort();
+
+      // Above operations should have no effect on the row, since they were aborted
+      txContext.start();
+      Get get = new Get(TestBytes.row);
+      Result result = txTable.get(get);
+      assertFalse(result.isEmpty());
+      assertArrayEquals(TestBytes.value, result.getValue(TestBytes.family, TestBytes.qualifier));
+      txContext.finish();
+    }
+  }
+
+  @Test
+  public void testDeleteRollback() throws Exception {
+    testDeleteRollback(TxConstants.ConflictDetection.ROW);
+    testDeleteRollback(TxConstants.ConflictDetection.COLUMN);
+    testDeleteRollback(TxConstants.ConflictDetection.NONE);
+  }
+
+  @Test
+  public void testMultiColumnFamilyRowDeleteRollback() throws Exception {
+    HTable hTable = createTable(Bytes.toBytes("TestMultColFam"), new byte[][] {TestBytes.family, TestBytes.family2});
+    try (TransactionAwareHTable txTable = new TransactionAwareHTable(hTable, TxConstants.ConflictDetection.ROW)) {
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+      txContext.start();
+      txTable.put(new Put(TestBytes.row).add(TestBytes.family, TestBytes.qualifier, TestBytes.value));
+      txContext.finish();
+
+      txContext.start();
+      //noinspection ConstantConditions
+      txContext.getCurrentTransaction().setVisibility(Transaction.VisibilityLevel.SNAPSHOT_ALL);
+      Result result = txTable.get(new Get(TestBytes.row));
+      Assert.assertEquals(1, result.getFamilyMap(TestBytes.family).size());
+      Assert.assertEquals(0, result.getFamilyMap(TestBytes.family2).size());
+      txContext.finish();
+
+      //Start a tx, delete the row and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row));
+      txContext.abort();
+
+      //Start a tx and scan all the col families to make sure none of them have delete markers
+      txContext.start();
+      txContext.getCurrentTransaction().setVisibility(Transaction.VisibilityLevel.SNAPSHOT_ALL);
+      result = txTable.get(new Get(TestBytes.row));
+      Assert.assertEquals(1, result.getFamilyMap(TestBytes.family).size());
+      Assert.assertEquals(0, result.getFamilyMap(TestBytes.family2).size());
+      txContext.finish();
+    }
+  }
+
   @Test
   public void testRowDelete() throws Exception {
     HTable hTable = createTable(Bytes.toBytes("TestRowDelete"), new byte[][]{TestBytes.family, TestBytes.family2});

--- a/tephra-hbase-compat-1.0-cdh/src/main/java/co/cask/tephra/hbase10cdh/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.0-cdh/src/main/java/co/cask/tephra/hbase10cdh/TransactionAwareHTable.java
@@ -26,6 +26,7 @@ import com.google.protobuf.ServiceException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
@@ -132,7 +133,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
       for (Set<ActionChange> cs : changeSets.values()) {
         size += cs.size();
       }
-      List<Delete> rollbackDeletes = new ArrayList<Delete>(size);
+      List<Delete> rollbackDeletes = new ArrayList<>(size);
       for (Map.Entry<Long, Set<ActionChange>> entry : changeSets.entrySet()) {
         long transactionTimestamp = entry.getKey();
         for (ActionChange change : entry.getValue()) {
@@ -589,11 +590,15 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
 
     Map<byte[], List<Cell>> familyToDelete = delete.getFamilyCellMap();
     if (familyToDelete.isEmpty()) {
-      // perform a row delete is we are using row-level conflict detection
+      // perform a row delete if we are using row-level conflict detection
       if (conflictLevel == TxConstants.ConflictDetection.ROW ||
-          conflictLevel == TxConstants.ConflictDetection.NONE) {
-        // no need to identify individual columns deleted
-        addToChangeSet(deleteRow, null, null);
+        conflictLevel == TxConstants.ConflictDetection.NONE) {
+        // Row delete leaves delete markers in all column families of the table
+        // Therefore get all the column families of the hTable from the HTableDescriptor and add them to the changeSet
+        for (HColumnDescriptor columnDescriptor : hTable.getTableDescriptor().getColumnFamilies()) {
+          // no need to identify individual columns deleted
+          addToChangeSet(deleteRow, columnDescriptor.getName(), null);
+        }
       } else {
         Result result = get(new Get(delete.getRow()));
         // Delete everything
@@ -620,7 +625,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
               conflictLevel == TxConstants.ConflictDetection.NONE) {
             // no need to identify individual columns deleted
             txDelete.deleteFamily(family);
-            addToChangeSet(deleteRow, null, null);
+            addToChangeSet(deleteRow, family, null);
           } else {
             Result result = get(new Get(delete.getRow()).addFamily(family));
             // Delete entire family
@@ -642,7 +647,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
   }
 
   private List<? extends Row> transactionalizeActions(List<? extends Row> actions) throws IOException {
-    List<Row> transactionalizedActions = new ArrayList<Row>(actions.size());
+    List<Row> transactionalizedActions = new ArrayList<>(actions.size());
     for (Row action : actions) {
       if (action instanceof Get) {
         transactionalizedActions.add(transactionalizeAction((Get) action));

--- a/tephra-hbase-compat-1.0-cdh/src/test/java/co/cask/tephra/hbase10cdh/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.0-cdh/src/test/java/co/cask/tephra/hbase10cdh/TransactionAwareHTableTest.java
@@ -384,6 +384,74 @@ public class TransactionAwareHTableTest {
     assertArrayEquals(TestBytes.value, value);
   }
 
+  private void testDeleteRollback(TxConstants.ConflictDetection conflictDetection) throws Exception {
+    String tableName = String.format("%s%s", "TestColFamilyDelete", conflictDetection);
+    HTable hTable = createTable(Bytes.toBytes(tableName), new byte[][]{TestBytes.family});
+    try (TransactionAwareHTable txTable = new TransactionAwareHTable(hTable, conflictDetection)) {
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+      txContext.start();
+      txTable.put(new Put(TestBytes.row).add(TestBytes.family, TestBytes.qualifier, TestBytes.value));
+      txContext.finish();
+
+      // Start a tx, delete the row and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row));
+      txContext.abort();
+
+      // Start a tx, delete a column family and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row).deleteFamily(TestBytes.family));
+      txContext.abort();
+
+      // Above operations should have no effect on the row, since they were aborted
+      txContext.start();
+      Get get = new Get(TestBytes.row);
+      Result result = txTable.get(get);
+      assertFalse(result.isEmpty());
+      assertArrayEquals(TestBytes.value, result.getValue(TestBytes.family, TestBytes.qualifier));
+      txContext.finish();
+    }
+  }
+
+  @Test
+  public void testDeleteRollback() throws Exception {
+    testDeleteRollback(TxConstants.ConflictDetection.ROW);
+    testDeleteRollback(TxConstants.ConflictDetection.COLUMN);
+    testDeleteRollback(TxConstants.ConflictDetection.NONE);
+  }
+
+  @Test
+  public void testMultiColumnFamilyRowDeleteRollback() throws Exception {
+    HTable hTable = createTable(Bytes.toBytes("TestMultColFam"), new byte[][] {TestBytes.family, TestBytes.family2});
+    try (TransactionAwareHTable txTable = new TransactionAwareHTable(hTable, TxConstants.ConflictDetection.ROW)) {
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+      txContext.start();
+      txTable.put(new Put(TestBytes.row).add(TestBytes.family, TestBytes.qualifier, TestBytes.value));
+      txContext.finish();
+
+      txContext.start();
+      //noinspection ConstantConditions
+      txContext.getCurrentTransaction().setVisibility(Transaction.VisibilityLevel.SNAPSHOT_ALL);
+      Result result = txTable.get(new Get(TestBytes.row));
+      Assert.assertEquals(1, result.getFamilyMap(TestBytes.family).size());
+      Assert.assertEquals(0, result.getFamilyMap(TestBytes.family2).size());
+      txContext.finish();
+
+      //Start a tx, delete the row and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row));
+      txContext.abort();
+
+      //Start a tx and scan all the col families to make sure none of them have delete markers
+      txContext.start();
+      txContext.getCurrentTransaction().setVisibility(Transaction.VisibilityLevel.SNAPSHOT_ALL);
+      result = txTable.get(new Get(TestBytes.row));
+      Assert.assertEquals(1, result.getFamilyMap(TestBytes.family).size());
+      Assert.assertEquals(0, result.getFamilyMap(TestBytes.family2).size());
+      txContext.finish();
+    }
+  }
+
   @Test
   public void testRowDelete() throws Exception {
     HTable hTable = createTable(Bytes.toBytes("TestRowDelete"), new byte[][]{TestBytes.family, TestBytes.family2});

--- a/tephra-hbase-compat-1.0/src/main/java/co/cask/tephra/hbase10/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.0/src/main/java/co/cask/tephra/hbase10/TransactionAwareHTable.java
@@ -26,6 +26,7 @@ import com.google.protobuf.ServiceException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
@@ -132,7 +133,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
       for (Set<ActionChange> cs : changeSets.values()) {
         size += cs.size();
       }
-      List<Delete> rollbackDeletes = new ArrayList<Delete>(size);
+      List<Delete> rollbackDeletes = new ArrayList<>(size);
       for (Map.Entry<Long, Set<ActionChange>> entry : changeSets.entrySet()) {
         long transactionTimestamp = entry.getKey();
         for (ActionChange change : entry.getValue()) {
@@ -589,11 +590,15 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
 
     Map<byte[], List<Cell>> familyToDelete = delete.getFamilyCellMap();
     if (familyToDelete.isEmpty()) {
-      // perform a row delete is we are using row-level conflict detection
+      // perform a row delete if we are using row-level conflict detection
       if (conflictLevel == TxConstants.ConflictDetection.ROW ||
           conflictLevel == TxConstants.ConflictDetection.NONE) {
-        // no need to identify individual columns deleted
-        addToChangeSet(deleteRow, null, null);
+        // Row delete leaves delete markers in all column families of the table
+        // Therefore get all the column families of the hTable from the HTableDescriptor and add them to the changeSet
+        for (HColumnDescriptor columnDescriptor : hTable.getTableDescriptor().getColumnFamilies()) {
+          // no need to identify individual columns deleted
+          addToChangeSet(deleteRow, columnDescriptor.getName(), null);
+        }
       } else {
         Result result = get(new Get(delete.getRow()));
         // Delete everything
@@ -620,7 +625,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
               conflictLevel == TxConstants.ConflictDetection.NONE) {
             // no need to identify individual columns deleted
             txDelete.deleteFamily(family);
-            addToChangeSet(deleteRow, null, null);
+            addToChangeSet(deleteRow, family, null);
           } else {
             Result result = get(new Get(delete.getRow()).addFamily(family));
             // Delete entire family
@@ -642,7 +647,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
   }
 
   private List<? extends Row> transactionalizeActions(List<? extends Row> actions) throws IOException {
-    List<Row> transactionalizedActions = new ArrayList<Row>(actions.size());
+    List<Row> transactionalizedActions = new ArrayList<>(actions.size());
     for (Row action : actions) {
       if (action instanceof Get) {
         transactionalizedActions.add(transactionalizeAction((Get) action));

--- a/tephra-hbase-compat-1.0/src/test/java/co/cask/tephra/hbase10/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.0/src/test/java/co/cask/tephra/hbase10/TransactionAwareHTableTest.java
@@ -384,6 +384,74 @@ public class TransactionAwareHTableTest {
     assertArrayEquals(TestBytes.value, value);
   }
 
+  private void testDeleteRollback(TxConstants.ConflictDetection conflictDetection) throws Exception {
+    String tableName = String.format("%s%s", "TestColFamilyDelete", conflictDetection);
+    HTable hTable = createTable(Bytes.toBytes(tableName), new byte[][]{TestBytes.family});
+    try (TransactionAwareHTable txTable = new TransactionAwareHTable(hTable, conflictDetection)) {
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+      txContext.start();
+      txTable.put(new Put(TestBytes.row).add(TestBytes.family, TestBytes.qualifier, TestBytes.value));
+      txContext.finish();
+
+      // Start a tx, delete the row and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row));
+      txContext.abort();
+
+      // Start a tx, delete a column family and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row).deleteFamily(TestBytes.family));
+      txContext.abort();
+
+      // Above operations should have no effect on the row, since they were aborted
+      txContext.start();
+      Get get = new Get(TestBytes.row);
+      Result result = txTable.get(get);
+      assertFalse(result.isEmpty());
+      assertArrayEquals(TestBytes.value, result.getValue(TestBytes.family, TestBytes.qualifier));
+      txContext.finish();
+    }
+  }
+
+  @Test
+  public void testDeleteRollback() throws Exception {
+    testDeleteRollback(TxConstants.ConflictDetection.ROW);
+    testDeleteRollback(TxConstants.ConflictDetection.COLUMN);
+    testDeleteRollback(TxConstants.ConflictDetection.NONE);
+  }
+
+  @Test
+  public void testMultiColumnFamilyRowDeleteRollback() throws Exception {
+    HTable hTable = createTable(Bytes.toBytes("TestMultColFam"), new byte[][] {TestBytes.family, TestBytes.family2});
+    try (TransactionAwareHTable txTable = new TransactionAwareHTable(hTable, TxConstants.ConflictDetection.ROW)) {
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+      txContext.start();
+      txTable.put(new Put(TestBytes.row).add(TestBytes.family, TestBytes.qualifier, TestBytes.value));
+      txContext.finish();
+
+      txContext.start();
+      //noinspection ConstantConditions
+      txContext.getCurrentTransaction().setVisibility(Transaction.VisibilityLevel.SNAPSHOT_ALL);
+      Result result = txTable.get(new Get(TestBytes.row));
+      Assert.assertEquals(1, result.getFamilyMap(TestBytes.family).size());
+      Assert.assertEquals(0, result.getFamilyMap(TestBytes.family2).size());
+      txContext.finish();
+
+      //Start a tx, delete the row and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row));
+      txContext.abort();
+
+      //Start a tx and scan all the col families to make sure none of them have delete markers
+      txContext.start();
+      txContext.getCurrentTransaction().setVisibility(Transaction.VisibilityLevel.SNAPSHOT_ALL);
+      result = txTable.get(new Get(TestBytes.row));
+      Assert.assertEquals(1, result.getFamilyMap(TestBytes.family).size());
+      Assert.assertEquals(0, result.getFamilyMap(TestBytes.family2).size());
+      txContext.finish();
+    }
+  }
+
   @Test
   public void testRowDelete() throws Exception {
     HTable hTable = createTable(Bytes.toBytes("TestRowDelete"), new byte[][]{TestBytes.family, TestBytes.family2});

--- a/tephra-hbase-compat-1.1/src/test/java/co/cask/tephra/hbase11/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.1/src/test/java/co/cask/tephra/hbase11/TransactionAwareHTableTest.java
@@ -381,6 +381,74 @@ public class TransactionAwareHTableTest {
     assertArrayEquals(TestBytes.value, value);
   }
 
+  private void testDeleteRollback(TxConstants.ConflictDetection conflictDetection) throws Exception {
+    String tableName = String.format("%s%s", "TestColFamilyDelete", conflictDetection);
+    HTable hTable = createTable(Bytes.toBytes(tableName), new byte[][]{TestBytes.family});
+    try (TransactionAwareHTable txTable = new TransactionAwareHTable(hTable, conflictDetection)) {
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+      txContext.start();
+      txTable.put(new Put(TestBytes.row).add(TestBytes.family, TestBytes.qualifier, TestBytes.value));
+      txContext.finish();
+
+      // Start a tx, delete the row and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row));
+      txContext.abort();
+
+      // Start a tx, delete a column family and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row).deleteFamily(TestBytes.family));
+      txContext.abort();
+
+      // Above operations should have no effect on the row, since they were aborted
+      txContext.start();
+      Get get = new Get(TestBytes.row);
+      Result result = txTable.get(get);
+      assertFalse(result.isEmpty());
+      assertArrayEquals(TestBytes.value, result.getValue(TestBytes.family, TestBytes.qualifier));
+      txContext.finish();
+    }
+  }
+
+  @Test
+  public void testDeleteRollback() throws Exception {
+    testDeleteRollback(TxConstants.ConflictDetection.ROW);
+    testDeleteRollback(TxConstants.ConflictDetection.COLUMN);
+    testDeleteRollback(TxConstants.ConflictDetection.NONE);
+  }
+
+  @Test
+  public void testMultiColumnFamilyRowDeleteRollback() throws Exception {
+    HTable hTable = createTable(Bytes.toBytes("TestMultColFam"), new byte[][] {TestBytes.family, TestBytes.family2});
+    try (TransactionAwareHTable txTable = new TransactionAwareHTable(hTable, TxConstants.ConflictDetection.ROW)) {
+      TransactionContext txContext = new TransactionContext(new InMemoryTxSystemClient(txManager), txTable);
+      txContext.start();
+      txTable.put(new Put(TestBytes.row).add(TestBytes.family, TestBytes.qualifier, TestBytes.value));
+      txContext.finish();
+
+      txContext.start();
+      //noinspection ConstantConditions
+      txContext.getCurrentTransaction().setVisibility(Transaction.VisibilityLevel.SNAPSHOT_ALL);
+      Result result = txTable.get(new Get(TestBytes.row));
+      Assert.assertEquals(1, result.getFamilyMap(TestBytes.family).size());
+      Assert.assertEquals(0, result.getFamilyMap(TestBytes.family2).size());
+      txContext.finish();
+
+      //Start a tx, delete the row and then abort the tx
+      txContext.start();
+      txTable.delete(new Delete(TestBytes.row));
+      txContext.abort();
+
+      //Start a tx and scan all the col families to make sure none of them have delete markers
+      txContext.start();
+      txContext.getCurrentTransaction().setVisibility(Transaction.VisibilityLevel.SNAPSHOT_ALL);
+      result = txTable.get(new Get(TestBytes.row));
+      Assert.assertEquals(1, result.getFamilyMap(TestBytes.family).size());
+      Assert.assertEquals(0, result.getFamilyMap(TestBytes.family2).size());
+      txContext.finish();
+    }
+  }
+
   @Test
   public void testRowDelete() throws Exception {
     HTable hTable = createTable(Bytes.toBytes("TestRowDelete"), new byte[][]{TestBytes.family, TestBytes.family2});


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/TEPHRA-131
Fix : Include the column family byte[] to the change set

Once the initial review is complete, the fix (including unit test) will be ported to other compact modules. 

Thanks to @JamesRTaylor for filing the JIRA and for also providing the patch.