### PR TITLE
TEPHRA-133 - handle transation edit log improper close

### DIFF
--- a/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
@@ -326,4 +326,16 @@ public class TxConstants {
       { DefaultSnapshotCodec.class, SnapshotCodecV2.class, SnapshotCodecV3.class, SnapshotCodecV4.class };
   }
 
+  /**
+   * Configuration for transaction log edit entries
+   */
+  public static final class TransactionLog {
+    /**
+     * Key used to denote the number of entries appended.
+     */
+    public static final String NUM_ENTRIES_APPENDED = "count";
+    public static final String VERSION_KEY = "version";
+    public static final byte CURRENT_VERSION = 2;
+  }
+
 }

--- a/tephra-core/src/main/java/co/cask/tephra/persist/AbstractTransactionLog.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/AbstractTransactionLog.java
@@ -145,7 +145,7 @@ public abstract class AbstractTransactionLog implements TransactionLog {
   private List<Entry> getPendingWrites() {
     synchronized (this) {
       List<Entry> save = this.pendingWrites;
-      this.pendingWrites = new LinkedList<Entry>();
+      this.pendingWrites = new LinkedList<>();
       return save;
     }
   }
@@ -163,13 +163,18 @@ public abstract class AbstractTransactionLog implements TransactionLog {
       tmpWriter = writer;
 
       List<Entry> currentPending = getPendingWrites();
-      // write out all accumulated Entries to hdfs.
+      if (!currentPending.isEmpty()) {
+        tmpWriter.commitMarker(currentPending.size());
+      }
+
+      // write out all accumulated entries to log.
       for (Entry e : currentPending) {
         tmpWriter.append(e);
         entryCount++;
         latestSeq = Math.max(latestSeq, e.getKey().get());
       }
     }
+
     long lastSynced = syncedUpTo.get();
     // someone else might have already synced our edits, avoid double syncing
     if (lastSynced < latestSeq) {

--- a/tephra-core/src/main/java/co/cask/tephra/persist/CommitMarkerCodec.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/CommitMarkerCodec.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.persist;
+
+import co.cask.tephra.TxConstants;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Ints;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.io.SequenceFile;
+
+import java.io.Closeable;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * Class to read and write commit markers used in {@link HDFSTransactionLogReaderV2} and above.
+ */
+public class CommitMarkerCodec implements Closeable {
+  private static final byte[] KEY_BYTES = TxConstants.TransactionLog.NUM_ENTRIES_APPENDED.getBytes(Charsets.UTF_8);
+  private final DataOutputBuffer rawKey;
+  private final DataOutputBuffer rawValue;
+  private SequenceFile.ValueBytes valueBytes;
+
+  public CommitMarkerCodec() {
+    this.rawKey = new DataOutputBuffer();
+    this.rawValue = new DataOutputBuffer();
+  }
+
+  @Override
+  public void close() throws IOException {
+    rawKey.close();
+    rawValue.close();
+  }
+
+  // 1. Returns the count when the marker is written correctly
+  // 2. If data is incorrect (for ex, incorrect key, mismatch in key/value/record length), we throw IOException
+  // since this indicates corrupted log file
+  // 3. If data is incomplete, then we throw EOFException which is handled gracefully by the calling method
+  // since we can recover without any consequence
+  public int readMarker(SequenceFile.Reader reader) throws IOException {
+    if (valueBytes == null) {
+      valueBytes = reader.createValueBytes();
+    }
+    rawKey.reset();
+    rawValue.reset();
+
+    // valueBytes need not be reset since nextRaw call does it (and it is a private method)
+    int status = reader.nextRaw(rawKey, valueBytes);
+
+    // if we reach EOF, return -1
+    if (status == -1) {
+      return -1;
+    }
+
+    // Check if the marker key is valid and return the count
+    if (isMarkerValid()) {
+      valueBytes.writeUncompressedBytes(rawValue);
+      rawValue.flush();
+      // rawValue.getData() may return a larger byte array but Ints.fromByteArray will only read the first four bytes
+      return Ints.fromByteArray(rawValue.getData());
+    }
+
+    // EOF not reached and marker is not valid, then thrown an IOException since we can't make progress
+    throw new IOException(String.format("Invalid key for num entries appended found %s, expected : %s",
+                                        new String(rawKey.getData()), TxConstants.TransactionLog.NUM_ENTRIES_APPENDED));
+  }
+
+  private boolean isMarkerValid() {
+    // rawKey should have the expected length and the matching bytes should start at index 0
+    return rawKey.getLength() == KEY_BYTES.length && Bytes.indexOf(rawKey.getData(), KEY_BYTES) == 0;
+  }
+
+  public static void writeMarker(SequenceFile.Writer writer, int count) throws IOException {
+    writer.appendRaw(KEY_BYTES, 0, KEY_BYTES.length, new CommitEntriesCount(count));
+  }
+
+  @VisibleForTesting
+  static final class CommitEntriesCount implements SequenceFile.ValueBytes {
+    private final int numEntries;
+
+    public CommitEntriesCount(int numEntries) {
+      this.numEntries = numEntries;
+    }
+
+    @Override
+    public void writeUncompressedBytes(DataOutputStream outStream) throws IOException {
+      outStream.write(Ints.toByteArray(numEntries));
+    }
+
+    @Override
+    public void writeCompressedBytes(DataOutputStream outStream) throws IllegalArgumentException, IOException {
+      throw new IllegalArgumentException("Commit Entries count writing is not expected to be compressed.");
+    }
+
+    @Override
+    public int getSize() {
+      return Ints.BYTES;
+    }
+  }
+}

--- a/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionLog.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,14 +16,16 @@
 
 package co.cask.tephra.persist;
 
+import co.cask.tephra.TxConstants;
 import co.cask.tephra.metrics.MetricsCollector;
-import com.google.common.base.Throwables;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +71,7 @@ public class HDFSTransactionLog extends AbstractTransactionLog {
     FileStatus status = fs.getFileStatus(logPath);
     long length = status.getLen();
 
-    LogReader reader = null;
+    TransactionLogReader reader = null;
     // check if this file needs to be recovered due to failure
     // Check for possibly empty file. With appends, currently Hadoop reports a
     // zero length even if the file has been sync'd. Revisit if HDFS-376 or
@@ -85,7 +87,7 @@ public class HDFSTransactionLog extends AbstractTransactionLog {
         FileStatus newStatus = fs.getFileStatus(logPath);
         LOG.info("New file size for " + logPath + " is " + newStatus.getLen());
         SequenceFile.Reader fileReader = new SequenceFile.Reader(fs, logPath, hConf);
-        reader = new LogReader(fileReader);
+        reader = new HDFSTransactionLogReaderSupplier(fileReader).get();
       } catch (EOFException e) {
         if (length <= 0) {
           // TODO should we ignore an empty, not-last log file if skip.errors
@@ -103,23 +105,31 @@ public class HDFSTransactionLog extends AbstractTransactionLog {
     } catch (IOException e) {
       throw e;
     }
-
     return reader;
   }
 
-  private static final class LogWriter implements TransactionLogWriter {
+  @VisibleForTesting
+  static final class LogWriter implements TransactionLogWriter {
     private final SequenceFile.Writer internalWriter;
-
     public LogWriter(FileSystem fs, Configuration hConf, Path logPath) throws IOException {
       // TODO: retry a few times to ride over transient failures?
-      this.internalWriter =
-        SequenceFile.createWriter(fs, hConf, logPath, LongWritable.class, TransactionEdit.class);
+      SequenceFile.Metadata metadata = new SequenceFile.Metadata();
+      metadata.set(new Text(TxConstants.TransactionLog.VERSION_KEY),
+                   new Text(Byte.toString(TxConstants.TransactionLog.CURRENT_VERSION)));
+
+      this.internalWriter = SequenceFile.createWriter(fs, hConf, logPath, LongWritable.class, TransactionEdit.class,
+                                                      SequenceFile.CompressionType.NONE, null, null, metadata);
       LOG.debug("Created a new TransactionLog writer for " + logPath);
     }
 
     @Override
     public void append(Entry entry) throws IOException {
       internalWriter.append(entry.getKey(), entry.getEdit());
+    }
+
+    @Override
+    public void commitMarker(int count) throws IOException {
+      CommitMarkerCodec.writeMarker(internalWriter, count);
     }
 
     @Override
@@ -130,47 +140,6 @@ public class HDFSTransactionLog extends AbstractTransactionLog {
     @Override
     public void close() throws IOException {
       internalWriter.close();
-    }
-  }
-
-  private static final class LogReader implements TransactionLogReader {
-
-    private boolean closed;
-    private SequenceFile.Reader reader;
-    private LongWritable key = new LongWritable();
-
-    public LogReader(SequenceFile.Reader reader) {
-      this.reader = reader;
-    }
-
-    @Override
-    public TransactionEdit next() {
-      try {
-        return next(new TransactionEdit());
-      } catch (IOException ioe) {
-        throw Throwables.propagate(ioe);
-      }
-    }
-
-    @Override
-    public TransactionEdit next(TransactionEdit reuse) throws IOException {
-      if (closed) {
-        return null;
-      }
-      boolean successful = reader.next(key, reuse);
-      if (successful) {
-        return reuse;
-      }
-      return null;
-    }
-
-    @Override
-    public void close() throws IOException {
-      if (closed) {
-        return;
-      }
-      reader.close();
-      closed = true;
     }
   }
 }

--- a/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionLogReaderSupplier.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionLogReaderSupplier.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.persist;
+
+import co.cask.tephra.TxConstants;
+import com.google.common.base.Supplier;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+
+/**
+ * Provides the correct version of {@link TransactionLogReader}, based on the log's version metadata,
+ * to read HDFS Transaction Logs.
+ */
+public class HDFSTransactionLogReaderSupplier implements Supplier<TransactionLogReader> {
+  private final SequenceFile.Reader reader;
+  private final byte version;
+  private TransactionLogReader logReader;
+
+  public HDFSTransactionLogReaderSupplier(SequenceFile.Reader reader) {
+    this.reader = reader;
+    Text versionInfo = reader.getMetadata().get(new Text(TxConstants.TransactionLog.VERSION_KEY));
+    this.version = versionInfo == null ? 1 : Byte.parseByte(versionInfo.toString());
+  }
+
+  @Override
+  public TransactionLogReader get() {
+    if (logReader != null) {
+      return logReader;
+    }
+
+    switch (version) {
+      case 2:
+        logReader = new HDFSTransactionLogReaderV2(reader);
+        return logReader;
+      case 1:
+        logReader = new HDFSTransactionLogReaderV1(reader);
+        return logReader;
+      default:
+        throw new IllegalArgumentException(String.format("Invalid version %s found in the Transaction Log", version));
+    }
+  }
+}

--- a/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionLogReaderV1.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionLogReaderV1.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.persist;
+
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.SequenceFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+/**
+ * {@link TransactionLogReader} that can read v1 (default) version of Transaction logs. The logs are expected to
+ * have a sequence of {@link TransactionEdit}s.
+ */
+public class HDFSTransactionLogReaderV1 implements TransactionLogReader {
+  private static final Logger LOG = LoggerFactory.getLogger(HDFSTransactionLogReaderV1.class);
+  private final SequenceFile.Reader reader;
+  private final LongWritable key;
+  private boolean closed;
+
+  public HDFSTransactionLogReaderV1(SequenceFile.Reader reader) {
+    this.reader = reader;
+    this.key = new LongWritable();
+  }
+
+  @Override
+  public TransactionEdit next() throws IOException {
+    return next(new TransactionEdit());
+  }
+
+  @Override
+  public TransactionEdit next(TransactionEdit reuse) throws IOException {
+    if (closed) {
+      return null;
+    }
+
+    try {
+      boolean successful = reader.next(key, reuse);
+      return successful ? reuse : null;
+    } catch (EOFException e) {
+      LOG.warn("Hit an unexpected EOF while trying to read the Transaction Edit. Skipping the entry.", e);
+      return null;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (closed) {
+      return;
+    }
+    reader.close();
+    closed = true;
+  }
+}

--- a/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionLogReaderV2.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/HDFSTransactionLogReaderV2.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.persist;
+
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.SequenceFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+/**
+ * {@link TransactionLogReader} that can read v2 version of Transaction logs. The logs are expected to
+ * have commit markers that indicates the size of the batch of {@link TransactionEdit}s (follows the marker),
+ * that were synced together. If the expected number of {@link TransactionEdit}s are not present then that set of
+ * {@link TransactionEdit}s are discarded.
+ */
+public class HDFSTransactionLogReaderV2 implements TransactionLogReader {
+  private static final Logger LOG = LoggerFactory.getLogger(HDFSTransactionLogReaderV2.class);
+
+  private final SequenceFile.Reader reader;
+  private final Queue<TransactionEdit> transactionEdits;
+  private final CommitMarkerCodec commitMarkerCodec;
+  private final LongWritable key;
+
+  private boolean closed;
+
+  public HDFSTransactionLogReaderV2(SequenceFile.Reader reader) {
+    this.reader = reader;
+    this.transactionEdits = new ArrayDeque<>();
+    this.key = new LongWritable();
+    this.commitMarkerCodec = new CommitMarkerCodec();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (closed) {
+      return;
+    }
+    try {
+      commitMarkerCodec.close();
+    } finally {
+      reader.close();
+      closed = true;
+    }
+  }
+
+  @Override
+  public TransactionEdit next() throws IOException {
+    return next(null);
+  }
+
+  @Override
+  public TransactionEdit next(TransactionEdit reuse) throws IOException {
+    if (closed) {
+      return null;
+    }
+
+    if (!transactionEdits.isEmpty()) {
+      return transactionEdits.remove();
+    }
+
+    // Fetch the 'marker' and read 'marker' number of edits
+    populateTransactionEdits();
+    return transactionEdits.poll();
+  }
+
+  private void populateTransactionEdits() throws IOException {
+    // read the marker to determine numEntries to read.
+    int numEntries = 0;
+    try {
+      // can throw EOFException if reading of incomplete commit marker, no other action required since we can safely
+      // ignore this
+      numEntries = commitMarkerCodec.readMarker(reader);
+    } catch (EOFException e) {
+      LOG.warn("Reached EOF in log while trying to read commit marker", e);
+    }
+
+    for (int i = 0; i < numEntries; i++) {
+      TransactionEdit edit = new TransactionEdit();
+      try {
+        if (reader.next(key, edit)) {
+          transactionEdits.add(edit);
+        } else {
+          throw new EOFException("Attempt to read TransactionEdit failed.");
+        }
+      } catch (EOFException e) {
+        // we have reached EOF before reading back numEntries, we clear the partial list and return.
+        LOG.warn("Reached EOF in log before reading {} entries. Ignoring all {} edits since the last marker",
+                 numEntries, transactionEdits.size(), e);
+        transactionEdits.clear();
+      }
+    }
+  }
+}

--- a/tephra-core/src/main/java/co/cask/tephra/persist/LocalFileTransactionLog.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/LocalFileTransactionLog.java
@@ -73,6 +73,11 @@ public class LocalFileTransactionLog extends AbstractTransactionLog {
     }
 
     @Override
+    public void commitMarker(int count) throws IOException {
+      // skip for local file
+    }
+
+    @Override
     public void sync() throws IOException {
       out.flush();
     }

--- a/tephra-core/src/main/java/co/cask/tephra/persist/TransactionLogWriter.java
+++ b/tephra-core/src/main/java/co/cask/tephra/persist/TransactionLogWriter.java
@@ -33,6 +33,14 @@ public interface TransactionLogWriter extends Closeable {
   void append(AbstractTransactionLog.Entry entry) throws IOException;
 
   /**
+   * Makes an entry of number of transaction entries that will follow in that log in a single sync.
+   *
+   * @param count Number of transaction entries.
+   * @throws IOException If an error occurs while writing the count to storage.
+   */
+  void commitMarker(int count) throws IOException;
+
+  /**
    * Syncs any pending transaction edits added through {@link #append(AbstractTransactionLog.Entry)},
    * but not yet flushed to durable storage.
    *

--- a/tephra-core/src/test/java/co/cask/tephra/persist/CommitMarkerCodecTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/CommitMarkerCodecTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.persist;
+
+import co.cask.tephra.TxConstants;
+import com.google.common.primitives.Ints;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.SequenceFile;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Unit Test for {@link CommitMarkerCodec}.
+ */
+public class CommitMarkerCodecTest {
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  private static final String LOG_FILE = "txlog";
+  private static final Random RANDOM = new Random();
+
+  private static MiniDFSCluster dfsCluster;
+  private static Configuration conf;
+  private static FileSystem fs;
+
+  @BeforeClass
+  public static void setupBeforeClass() throws Exception {
+    Configuration hConf = new Configuration();
+    hConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TMP_FOLDER.newFolder().getAbsolutePath());
+
+    dfsCluster = new MiniDFSCluster.Builder(hConf).numDataNodes(1).build();
+    conf = new Configuration(dfsCluster.getFileSystem().getConf());
+    fs = FileSystem.newInstance(FileSystem.getDefaultUri(conf), conf);
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    dfsCluster.shutdown();
+  }
+
+  @Test
+  public void testRandomCommitMarkers() throws Exception {
+    List<Integer> randomInts = new ArrayList<>();
+    Path newLog = new Path(TMP_FOLDER.newFolder().getAbsolutePath(), LOG_FILE);
+
+    // Write a bunch of random commit markers
+    try (SequenceFile.Writer writer = SequenceFile.createWriter(fs, conf, newLog, LongWritable.class,
+                                                                LongWritable.class,
+                                                                SequenceFile.CompressionType.NONE)) {
+      for (int i = 0; i < 1000; i++) {
+        int randomNum = RANDOM.nextInt(Integer.MAX_VALUE);
+        CommitMarkerCodec.writeMarker(writer, randomNum);
+        randomInts.add(randomNum);
+      }
+      writer.hflush();
+      writer.hsync();
+    }
+
+    // Read the commit markers back to verify the marker
+    try (SequenceFile.Reader reader = new SequenceFile.Reader(fs, newLog, conf);
+         CommitMarkerCodec markerCodec = new CommitMarkerCodec()) {
+      for (int num : randomInts) {
+        Assert.assertEquals(num, markerCodec.readMarker(reader));
+      }
+    }
+  }
+
+  private static class IncompleteValueBytes implements SequenceFile.ValueBytes {
+
+    @Override
+    public void writeUncompressedBytes(DataOutputStream outStream) throws IOException {
+      // don't write anything to simulate incomplete record
+    }
+
+    @Override
+    public void writeCompressedBytes(DataOutputStream outStream) throws IllegalArgumentException, IOException {
+      throw new IllegalArgumentException("Not possible");
+    }
+
+    @Override
+    public int getSize() {
+      return Ints.BYTES;
+    }
+  }
+
+  @Test
+  public void testIncompleteCommitMarker() throws Exception {
+    Path newLog = new Path(TMP_FOLDER.newFolder().getAbsolutePath(), LOG_FILE);
+    try (SequenceFile.Writer writer = SequenceFile.createWriter(fs, conf, newLog, LongWritable.class,
+                                                                LongWritable.class,
+                                                                SequenceFile.CompressionType.NONE)) {
+      String key = TxConstants.TransactionLog.NUM_ENTRIES_APPENDED;
+      SequenceFile.ValueBytes valueBytes = new IncompleteValueBytes();
+      writer.appendRaw(key.getBytes(), 0, key.length(), valueBytes);
+      writer.hflush();
+      writer.hsync();
+    }
+
+    // Read the incomplete commit marker
+    try (SequenceFile.Reader reader = new SequenceFile.Reader(fs, newLog, conf);
+         CommitMarkerCodec markerCodec = new CommitMarkerCodec()) {
+      try {
+        markerCodec.readMarker(reader);
+        Assert.fail("Expected EOF Exception to be thrown");
+      } catch (EOFException e) {
+        // expected since we didn't write the value bytes
+      }
+    }
+  }
+
+  @Test
+  public void testIncorrectCommitMarker() throws Exception {
+    Path newLog = new Path(TMP_FOLDER.newFolder().getAbsolutePath(), LOG_FILE);
+
+    // Write an incorrect marker
+    try (SequenceFile.Writer writer = SequenceFile.createWriter(fs, conf, newLog, LongWritable.class,
+                                                                LongWritable.class,
+                                                                SequenceFile.CompressionType.NONE)) {
+      String invalidKey = "IncorrectKey";
+      SequenceFile.ValueBytes valueBytes = new CommitMarkerCodec.CommitEntriesCount(100);
+      writer.appendRaw(invalidKey.getBytes(), 0, invalidKey.length(), valueBytes);
+      writer.hflush();
+      writer.hsync();
+    }
+
+    // Read the commit markers back to verify the marker
+    try (SequenceFile.Reader reader = new SequenceFile.Reader(fs, newLog, conf);
+         CommitMarkerCodec markerCodec = new CommitMarkerCodec()) {
+      try {
+        markerCodec.readMarker(reader);
+        Assert.fail("Expected an IOException to be thrown");
+      } catch (IOException e) {
+        // expected
+      }
+    }
+  }
+}

--- a/tephra-core/src/test/java/co/cask/tephra/persist/HDFSTransactionLogTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/HDFSTransactionLogTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2012-2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.persist;
+
+import co.cask.tephra.TxConstants;
+import co.cask.tephra.metrics.MetricsCollector;
+import co.cask.tephra.metrics.TxMetricsCollector;
+import co.cask.tephra.util.TransactionEditUtil;
+import com.google.common.io.Closeables;
+import com.google.common.primitives.Longs;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+/**
+ * Testing for complete and partial sycs of {@link TransactionEdit} to {@link HDFSTransactionLog}
+ */
+public class HDFSTransactionLogTest {
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  private static final String LOG_FILE_PREFIX = "txlog.";
+
+  private static MiniDFSCluster dfsCluster;
+  private static Configuration conf;
+  private static MetricsCollector metricsCollector;
+
+  @BeforeClass
+  public static void setupBeforeClass() throws Exception {
+    Configuration hConf = new Configuration();
+    hConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TMP_FOLDER.newFolder().getAbsolutePath());
+
+    dfsCluster = new MiniDFSCluster.Builder(hConf).numDataNodes(1).build();
+    conf = new Configuration(dfsCluster.getFileSystem().getConf());
+    metricsCollector = new TxMetricsCollector();
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    dfsCluster.shutdown();
+  }
+
+  private Configuration getConfiguration() throws IOException {
+    // tests should use the current user for HDFS
+    conf.unset(TxConstants.Manager.CFG_TX_HDFS_USER);
+    conf.set(TxConstants.Manager.CFG_TX_SNAPSHOT_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
+    return conf;
+  }
+
+  private HDFSTransactionLog getHDFSTransactionLog(Configuration conf,
+                                                   FileSystem fs, long timeInMillis) throws Exception {
+    String snapshotDir = conf.get(TxConstants.Manager.CFG_TX_SNAPSHOT_DIR);
+    Path newLog = new Path(snapshotDir, LOG_FILE_PREFIX + timeInMillis);
+    return new HDFSTransactionLog(fs, conf, newLog, timeInMillis, metricsCollector);
+  }
+
+  private SequenceFile.Writer getSequenceFileWriter(Configuration configuration, FileSystem fs,
+                                                    long timeInMillis, boolean withMarker) throws IOException {
+    String snapshotDir = configuration.get(TxConstants.Manager.CFG_TX_SNAPSHOT_DIR);
+    Path newLog = new Path(snapshotDir, LOG_FILE_PREFIX + timeInMillis);
+    SequenceFile.Metadata metadata = new SequenceFile.Metadata();
+    if (withMarker) {
+      metadata.set(new Text(TxConstants.TransactionLog.VERSION_KEY),
+                   new Text(Byte.toString(TxConstants.TransactionLog.CURRENT_VERSION)));
+    }
+    return SequenceFile.createWriter(fs, configuration, newLog, LongWritable.class,
+                                     TransactionEdit.class, SequenceFile.CompressionType.NONE, null, null, metadata);
+  }
+
+  private void writeNumWrites(SequenceFile.Writer writer, final int size) throws Exception {
+    String key = TxConstants.TransactionLog.NUM_ENTRIES_APPENDED;
+    CommitMarkerCodec.writeMarker(writer, size);
+  }
+
+  private void testTransactionLogSync(int totalCount, int batchSize, boolean withMarker, boolean isComplete)
+    throws Exception {
+    List<TransactionEdit> edits = TransactionEditUtil.createRandomEdits(totalCount);
+    long timestamp = System.currentTimeMillis();
+    Configuration configuration = getConfiguration();
+    FileSystem fs = FileSystem.newInstance(FileSystem.getDefaultUri(configuration), configuration);
+    SequenceFile.Writer writer = getSequenceFileWriter(configuration, fs, timestamp, withMarker);
+    AtomicLong logSequence = new AtomicLong();
+    HDFSTransactionLog transactionLog = getHDFSTransactionLog(configuration, fs, timestamp);
+    AbstractTransactionLog.Entry entry;
+
+    for (int i = 0; i < totalCount - batchSize; i += batchSize) {
+      if (withMarker) {
+        writeNumWrites(writer, batchSize);
+      }
+      for (int j = 0; j < batchSize; j++) {
+        entry = new AbstractTransactionLog.Entry(new LongWritable(logSequence.getAndIncrement()), edits.get(j));
+        writer.append(entry.getKey(), entry.getEdit());
+      }
+      writer.syncFs();
+    }
+
+    if (withMarker) {
+      writeNumWrites(writer, batchSize);
+    }
+
+    for (int i = totalCount - batchSize; i < totalCount - 1; i++) {
+      entry = new AbstractTransactionLog.Entry(new LongWritable(logSequence.getAndIncrement()), edits.get(i));
+      writer.append(entry.getKey(), entry.getEdit());
+    }
+
+    entry = new AbstractTransactionLog.Entry(new LongWritable(logSequence.getAndIncrement()),
+                                             edits.get(totalCount - 1));
+    if (isComplete) {
+      writer.append(entry.getKey(), entry.getEdit());
+    } else {
+      byte[] bytes = Longs.toByteArray(entry.getKey().get());
+      writer.appendRaw(bytes, 0, bytes.length, new SequenceFile.ValueBytes() {
+        @Override
+        public void writeUncompressedBytes(DataOutputStream outStream) throws IOException {
+          byte[] test = new byte[]{0x2};
+          outStream.write(test, 0, 1);
+        }
+
+        @Override
+        public void writeCompressedBytes(DataOutputStream outStream) throws IllegalArgumentException, IOException {
+          // no-op
+        }
+
+        @Override
+        public int getSize() {
+          // mimic size longer than the actual byte array size written, so we would reach EOF
+          return 12;
+        }
+      });
+    }
+    writer.syncFs();
+    Closeables.closeQuietly(writer);
+
+    // now let's try to read this log
+    TransactionLogReader reader = transactionLog.getReader();
+    int syncedEdits = 0;
+    while (reader.next() != null) {
+      // testing reading the transaction edits
+      syncedEdits++;
+    }
+    if (isComplete) {
+      Assert.assertEquals(totalCount, syncedEdits);
+    } else {
+      Assert.assertEquals(totalCount - batchSize, syncedEdits);
+    }
+  }
+
+  @Test
+  public void testTransactionLogNewVersion() throws Exception {
+    // in-complete sync
+    testTransactionLogSync(1000, 1, true, false);
+    testTransactionLogSync(2000, 5, true, false);
+
+    // complete sync
+    testTransactionLogSync(1000, 1, true, true);
+    testTransactionLogSync(2000, 5, true, true);
+  }
+
+  @Test
+  public void testTransactionLogOldVersion() throws Exception {
+    // in-complete sync
+    testTransactionLogSync(1000, 1, false, false);
+
+    // complete sync
+    testTransactionLogSync(2000, 5, false, true);
+  }
+}

--- a/tephra-core/src/test/java/co/cask/tephra/persist/HDFSTransactionStateStorageTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/HDFSTransactionStateStorageTest.java
@@ -19,7 +19,6 @@ package co.cask.tephra.persist;
 import co.cask.tephra.TxConstants;
 import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
-import co.cask.tephra.snapshot.SnapshotCodecV2;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.AfterClass;
@@ -61,7 +60,6 @@ public class HDFSTransactionStateStorageTest extends AbstractTransactionStateSto
     // tests should use the current user for HDFS
     conf.unset(TxConstants.Manager.CFG_TX_HDFS_USER);
     conf.set(TxConstants.Manager.CFG_TX_SNAPSHOT_DIR, tmpFolder.newFolder().getAbsolutePath());
-    conf.set(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES, SnapshotCodecV2.class.getName());
     return conf;
   }
 

--- a/tephra-core/src/test/java/co/cask/tephra/persist/LocalTransactionStateStorageTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/persist/LocalTransactionStateStorageTest.java
@@ -23,7 +23,7 @@ import co.cask.tephra.TxConstants;
 import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.snapshot.DefaultSnapshotCodec;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
-import co.cask.tephra.snapshot.SnapshotCodecV2;
+import co.cask.tephra.snapshot.SnapshotCodecV4;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
@@ -56,8 +56,7 @@ public class LocalTransactionStateStorageTest extends AbstractTransactionStateSt
     File testDir = tmpDir.newFolder(testName);
     Configuration conf = new Configuration();
     conf.set(TxConstants.Manager.CFG_TX_SNAPSHOT_LOCAL_DIR, testDir.getAbsolutePath());
-    conf.set(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES, SnapshotCodecV2.class.getName());
-
+    conf.set(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES, SnapshotCodecV4.class.getName());
     return conf;
   }
 

--- a/tephra-core/src/test/java/co/cask/tephra/util/TransactionEditUtil.java
+++ b/tephra-core/src/test/java/co/cask/tephra/util/TransactionEditUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.util;
+
+import co.cask.tephra.ChangeId;
+import co.cask.tephra.TransactionType;
+import co.cask.tephra.persist.TransactionEdit;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Util class for {@link TransactionEdit} related tests.
+ */
+public final class TransactionEditUtil {
+  private static Random random = new Random();
+
+  /**
+   * Generates a number of semi-random {@link TransactionEdit} instances.
+   * These are just randomly selected from the possible states, so would not necessarily reflect a real-world
+   * distribution.
+   *
+   * @param numEntries how many entries to generate in the returned list.
+   * @return a list of randomly generated transaction log edits.
+   */
+  public static List<TransactionEdit> createRandomEdits(int numEntries) {
+    List<TransactionEdit> edits = Lists.newArrayListWithCapacity(numEntries);
+    for (int i = 0; i < numEntries; i++) {
+      TransactionEdit.State nextType = TransactionEdit.State.values()[random.nextInt(6)];
+      long writePointer = Math.abs(random.nextLong());
+      switch (nextType) {
+        case INPROGRESS:
+          edits.add(
+            TransactionEdit.createStarted(writePointer, writePointer - 1,
+                                          System.currentTimeMillis() + 300000L, TransactionType.SHORT));
+          break;
+        case COMMITTING:
+          edits.add(TransactionEdit.createCommitting(writePointer, generateChangeSet(10)));
+          break;
+        case COMMITTED:
+          edits.add(TransactionEdit.createCommitted(writePointer, generateChangeSet(10), writePointer + 1,
+                                                    random.nextBoolean()));
+          break;
+        case INVALID:
+          edits.add(TransactionEdit.createInvalid(writePointer));
+          break;
+        case ABORTED:
+          edits.add(TransactionEdit.createAborted(writePointer, TransactionType.SHORT, null));
+          break;
+        case MOVE_WATERMARK:
+          edits.add(TransactionEdit.createMoveWatermark(writePointer));
+          break;
+      }
+    }
+    return edits;
+  }
+
+  private static Set<ChangeId> generateChangeSet(int numEntries) {
+    Set<ChangeId> changes = Sets.newHashSet();
+    for (int i = 0; i < numEntries; i++) {
+      byte[] bytes = new byte[8];
+      random.nextBytes(bytes);
+      changes.add(new ChangeId(bytes));
+    }
+    return changes;
+  }
+}


### PR DESCRIPTION
1) we persist the count of transaction log-edits we are appending before performing the append.
2) with this information, while reading the transaction log for replay, we know  the count of edits to read and if we reach EOF before reading those entries, we will safely ignore the entries we have read so far.
3) we use a buffer to add the transaction edit entries and serve from that buffer. we repeat step-2 after the buffer is emptied.

for backward compatibility, we have a version metadata written to sequence file and we use the new-logic only if the version metadata is present in the sequence file. 

files which was written with previous version of code and if they were closed abruptly and hit EOF, we would still face the issue described in TEPHRA-133.