### PR TITLE
TimedObjectPool

### DIFF
--- a/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
@@ -218,6 +218,10 @@ public class TxConstants {
     public static final String CFG_DATA_TX_CLIENT_COUNT
       = "data.tx.client.count";
 
+    /** to specify the timeout (in milliseconds) for client provider "timed-pool". */
+    public static final String CFG_DATA_TX_CLIENT_POOL_TIMEOUT
+      = "data.tx.client.pool.timeout";
+
     /** to specify the retry strategy for a failed thrift call. */
     public static final String CFG_DATA_TX_CLIENT_RETRY_STRATEGY
       = "data.tx.client.retry.strategy";
@@ -227,7 +231,7 @@ public class TxConstants {
       = "data.tx.client.retry.attempts";
 
     /** to specify the initial sleep time for retry strategy backoff. */
-    public static final String CFG_DATA_TX_CLIENT_BACKOFF_INIITIAL
+    public static final String CFG_DATA_TX_CLIENT_BACKOFF_INITIAL
       = "data.tx.client.retry.backoff.initial";
 
     /** to specify the backoff factor for retry strategy backoff. */
@@ -239,16 +243,20 @@ public class TxConstants {
       = "data.tx.client.retry.backoff.limit";
 
     /** the default tx client socket timeout in milli seconds. */
-    public static final int DEFAULT_DATA_TX_CLIENT_TIMEOUT
+    public static final int DEFAULT_DATA_TX_CLIENT_TIMEOUT_MS
       = 30 * 1000;
 
-    /** default number of pooled tx clients. */
+    /** default number of tx clients for client provider "pool". */
     public static final int DEFAULT_DATA_TX_CLIENT_COUNT
       = 5;
 
+    /** default timeout of timed-pooled tx clients for client provider "timed-pool". */
+    public static final long DEFAULT_DATA_TX_CLIENT_POOL_TIMEOUT_MS
+      = TimeUnit.MINUTES.toMillis(1);
+
     /** default tx client provider strategy. */
     public static final String DEFAULT_DATA_TX_CLIENT_PROVIDER
-      = "pool";
+      = "timed-pool";
 
     /** retry strategy for thrift clients, e.g. backoff, or n-times. */
     public static final String DEFAULT_DATA_TX_CLIENT_RETRY_STRATEGY
@@ -259,7 +267,7 @@ public class TxConstants {
       = 2;
 
     /** default initial sleep is 100ms. */
-    public static final int DEFAULT_DATA_TX_CLIENT_BACKOFF_INIITIAL
+    public static final int DEFAULT_DATA_TX_CLIENT_BACKOFF_INITIAL
       = 100;
 
     /** default backoff factor is 4. */

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/AbstractClientProvider.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/AbstractClientProvider.java
@@ -111,7 +111,7 @@ public abstract class AbstractClientProvider implements ThriftClientProvider {
     // now we have an address and port, try to connect a client
     if (timeout < 0) {
       timeout = configuration.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_TIMEOUT,
-          TxConstants.Service.DEFAULT_DATA_TX_CLIENT_TIMEOUT);
+          TxConstants.Service.DEFAULT_DATA_TX_CLIENT_TIMEOUT_MS);
     }
     LOG.info("Attempting to connect to tx service at " +
                address + ":" + port + " with timeout " + timeout + " ms.");

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/ElasticPooledClientProvider.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/ElasticPooledClientProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2012-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.distributed;
+
+import co.cask.tephra.TxConstants;
+import com.google.common.base.Throwables;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.thrift.TException;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is an tx client provider that uses a bounded size pool of connections.
+ */
+public class ElasticPooledClientProvider extends AbstractClientProvider {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ElasticPooledClientProvider.class);
+
+  // we will use this as a pool of tx clients
+  class TxClientPool extends ElasticPool<TransactionServiceThriftClient, TException> {
+    TxClientPool(int sizeLimit) {
+      super(sizeLimit);
+    }
+
+    @Override
+    protected TransactionServiceThriftClient create() throws TException {
+      return newClient();
+    }
+
+    @Override
+    protected void destroy(TransactionServiceThriftClient client) {
+      client.close();
+    }
+  }
+
+  // we will use this as a pool of tx clients
+  private volatile TxClientPool clients;
+
+  // the limit for the number of active clients
+  private int maxClients;
+
+  public ElasticPooledClientProvider(Configuration conf, DiscoveryServiceClient discoveryServiceClient) {
+    super(conf, discoveryServiceClient);
+  }
+
+  private void initializePool() throws TException {
+    // initialize the super class (needed for service discovery)
+    super.initialize();
+
+    // create a (empty) pool of tx clients
+    maxClients = configuration.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_COUNT,
+        TxConstants.Service.DEFAULT_DATA_TX_CLIENT_COUNT);
+    if (maxClients < 1) {
+      LOG.warn("Configuration of " + TxConstants.Service.CFG_DATA_TX_CLIENT_COUNT +
+                                 " is invalid: value is " + maxClients + " but must be at least 1. " +
+                                 "Using 1 as a fallback. ");
+      maxClients = 1;
+    }
+    this.clients = new TxClientPool(maxClients);
+  }
+
+  @Override
+  public TransactionServiceThriftClient getClient() throws TException {
+    return getClientPool().obtain();
+  }
+
+  @Override
+  public void returnClient(TransactionServiceThriftClient client) {
+    getClientPool().release(client);
+  }
+
+  @Override
+  public void discardClient(TransactionServiceThriftClient client) {
+    getClientPool().discard(client);
+  }
+
+  @Override
+  public String toString() {
+    return "Elastic pool of size " + this.maxClients;
+  }
+
+  private TxClientPool getClientPool() {
+    if (clients != null) {
+      return clients;
+    }
+
+    synchronized (this) {
+      if (clients == null) {
+        try {
+          initializePool();
+        } catch (TException e) {
+          LOG.error("Failed to initialize Tx client provider", e);
+          throw Throwables.propagate(e);
+        }
+      }
+    }
+    return clients;
+  }
+}

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/RetryWithBackoff.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/RetryWithBackoff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -81,13 +81,13 @@ public class RetryWithBackoff extends RetryStrategy {
     int maxSleep; // max sleep time. stop retrying when we exceed this
 
     public Provider() {
-      initialSleep = TxConstants.Service.DEFAULT_DATA_TX_CLIENT_BACKOFF_INIITIAL;
+      initialSleep = TxConstants.Service.DEFAULT_DATA_TX_CLIENT_BACKOFF_INITIAL;
       backoffFactor = TxConstants.Service.DEFAULT_DATA_TX_CLIENT_BACKOFF_FACTOR;
       maxSleep = TxConstants.Service.DEFAULT_DATA_TX_CLIENT_BACKOFF_LIMIT;
     }
 
     public void configure(Configuration config) {
-      initialSleep = config.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_BACKOFF_INIITIAL, initialSleep);
+      initialSleep = config.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_BACKOFF_INITIAL, initialSleep);
       backoffFactor = config.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_BACKOFF_FACTOR, backoffFactor);
       maxSleep = config.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_BACKOFF_LIMIT, maxSleep);
     }

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/ThreadLocalClientProvider.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/ThreadLocalClientProvider.java
@@ -30,8 +30,7 @@ public class ThreadLocalClientProvider extends AbstractClientProvider {
   private static final Logger LOG =
       LoggerFactory.getLogger(ThreadLocalClientProvider.class);
 
-  ThreadLocal<TransactionServiceThriftClient> clients =
-      new ThreadLocal<TransactionServiceThriftClient>();
+  ThreadLocal<TransactionServiceThriftClient> clients = new ThreadLocal<>();
 
   public ThreadLocalClientProvider(Configuration conf, DiscoveryServiceClient discoveryServiceClient) {
     super(conf, discoveryServiceClient);

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/TimedObjectPool.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/TimedObjectPool.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.distributed;
+
+import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+
+/**
+ * A TimedObjectPool is an object pool that can dynamically shrink and grow.
+ * Objects in the pool will be destroyed and discarded based upon a configured
+ * timeout. For instance, if the time out is one minute, and an object hasn't
+ * been used for two minutes, then the object will be cleaned up the next time
+ * that the cleanup happens.
+ *
+ * Normally, an element is obtained by a client and then returned to the pool
+ * after use. However, if the element gets into a bad state, the client can
+ * also discard the element. This will cause the element to be removed from
+ * the pool, and for a subsequent request, a new element can be created
+ * on the fly to replace the discarded one.
+ *
+ * The pool starts with zero (active) elements. Every time a client attempts
+ * to obtain an element, an element from the pool is returned if available.
+ * Otherwise, a new element is created (using abstract method create(), this
+ * must be overridden by all implementations), and the number of active elements
+ * is increased by one.
+ *
+ * Every time an element is discarded, it is "destroyed" in order to properly
+ * release all of its resources before discarding. Every time an element is
+ * returned to the pool, it is "recycled" to restore its fresh state for the
+ * next use.
+ *
+ * @param <T> the type of the elements
+ * @param <E> the type of exception thrown by create()
+ */
+public abstract class TimedObjectPool<T, E extends Exception> {
+
+  /**
+   * A method to create a new element. Will be called every time {@link #obtain}
+   * is called and the pool of available elements is empty.
+   *
+   * @return a new element
+   */
+  protected abstract T create() throws E;
+
+  /**
+   * A method to destroy an element. This gets called every time an element
+   * is discarded, to properly release all resources that the element might
+   * hold.
+   *
+   * @param element the element to destroy
+   */
+  protected void destroy(T element) {
+    // by default do nothing
+  }
+
+  /**
+   * A method to recycle an existing element when it is returned to the pool.
+   * This method ensures that the element is in a fresh state before it can
+   * be reused by the next agent.
+   *
+   * @param element the element to recycle
+   */
+  protected void recycle(T element) {
+    // by default do nothing
+  }
+
+
+  private final class TimestampedEntry {
+    private final T element;
+    private final long timestamp;
+
+    private TimestampedEntry(T element, long timestamp) {
+      this.element = element;
+      this.timestamp = timestamp;
+    }
+
+    private T getElement() {
+      return element;
+    }
+
+    private long getTimestamp() {
+      return timestamp;
+    }
+  }
+
+  // holds all currently available elements, with the elements at the head
+  // being the most recently accessed
+  private final Deque<TimestampedEntry> elements;
+
+  // timeout, in milliseconds, after which an element can be destroyed and removed
+  private final long timeoutMillis;
+
+  private final AtomicBoolean isCleanupInProgress = new AtomicBoolean(false);
+
+  public TimedObjectPool(long timeoutMillis) {
+    this.elements = new ConcurrentLinkedDeque<>();
+    this.timeoutMillis = timeoutMillis;
+  }
+
+  /**
+   * Get a element from the pool. If there is an available element in
+   * the pool, it will be returned. Otherwise, a new element is created with
+   * create() and returned.
+   * Note that housekeeping is done within this method.
+   *
+   * @return an element
+   */
+  public T obtain() throws E {
+    T element = getOrCreate();
+    doCleanup();
+    return element;
+  }
+
+  /**
+   * Goes through all elements and destroys and removes the elements that have
+   * not been used for a time period greater than or equal to the configured timeout.
+   */
+  private void doCleanup() {
+    // Only one thread needs to do cleanup at any given time.
+    if (!isCleanupInProgress.compareAndSet(false, true)) {
+      return;
+    }
+
+    try {
+      long cleanupTime = System.currentTimeMillis();
+
+      TimestampedEntry entry;
+      while ((entry = getNextEntryForCleanup(cleanupTime)) != null) {
+        destroy(entry.getElement());
+      }
+    } finally {
+      isCleanupInProgress.set(false);
+    }
+  }
+
+  // return the entry to cleanup, or null to signify that there is no element that needs cleaning up
+  @Nullable
+  private TimestampedEntry getNextEntryForCleanup(long cleanupTime) {
+    // if the last element doesn't need expiry, simply return
+    final TimestampedEntry last = elements.peekLast();
+    if (last == null || cleanupTime - last.getTimestamp() < timeoutMillis) {
+      return null;
+    }
+
+    final TimestampedEntry entry = elements.pollLast();
+    if (entry == null) {
+      return null;
+    }
+    if (cleanupTime - entry.getTimestamp() < timeoutMillis) {
+      // add it back to the tail, if it doesn't require expiring
+      // since cleanup happens only from one thread, and we add the single entry to the tail of the queue,
+      // time ordering of the entries is maintained.
+      elements.addLast(entry);
+      return null;
+    }
+    return entry;
+  }
+
+  /**
+   * Returns an element to the pool of available elements. The element must
+   * have been obtained from this pool through obtain(). The recycle() method
+   * is called before the element is available for obtain().
+   *
+   * @param element the element to be returned
+   */
+  public void release(T element) {
+    recycle(element);
+    elements.addFirst(new TimestampedEntry(element, System.currentTimeMillis()));
+  }
+
+  /**
+   * Discard an element from the pool. The element must have been obtained
+   * from this pool. The destroy() method will be called.
+   *
+   * @param element the element to be discarded
+   */
+  public void discard(T element) {
+    destroy(element);
+  }
+
+  /**
+   * If the pool has an available element, return it. Otherwise,
+   * create a new element and return it.
+   * @return An element of type {@link T}.
+   */
+  private T getOrCreate() throws E {
+    TimestampedEntry entry = elements.pollFirst();
+    if (entry != null) {
+      // a entry was available, all good
+      return entry.getElement();
+    }
+    return create();
+  }
+}

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/TransactionServiceClient.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/TransactionServiceClient.java
@@ -246,7 +246,7 @@ public class TransactionServiceClient implements TransactionSystemClient {
 
       } finally {
         // in case any other exception happens (other than TException), and
-        // also in case of succeess, the client must be returned to the pool.
+        // also in case of success, the client must be returned to the pool.
         if (client != null) {
           provider.returnClient(client);
         }

--- a/tephra-core/src/main/java/co/cask/tephra/runtime/TransactionClientModule.java
+++ b/tephra-core/src/main/java/co/cask/tephra/runtime/TransactionClientModule.java
@@ -17,9 +17,10 @@
 package co.cask.tephra.runtime;
 
 import co.cask.tephra.TxConstants;
-import co.cask.tephra.distributed.PooledClientProvider;
+import co.cask.tephra.distributed.ElasticPooledClientProvider;
 import co.cask.tephra.distributed.ThreadLocalClientProvider;
 import co.cask.tephra.distributed.ThriftClientProvider;
+import co.cask.tephra.distributed.TimedPooledClientProvider;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -63,8 +64,10 @@ public class TransactionClientModule extends AbstractModule {
       String provider = cConf.get(TxConstants.Service.CFG_DATA_TX_CLIENT_PROVIDER,
                                   TxConstants.Service.DEFAULT_DATA_TX_CLIENT_PROVIDER);
       ThriftClientProvider clientProvider;
-      if ("pool".equals(provider)) {
-        clientProvider = new PooledClientProvider(cConf, discoveryServiceClient);
+      if ("timed-pool".equals(provider)) {
+        clientProvider = new TimedPooledClientProvider(cConf, discoveryServiceClient);
+      } else if ("pool".equals(provider)) {
+        clientProvider = new ElasticPooledClientProvider(cConf, discoveryServiceClient);
       } else if ("thread-local".equals(provider)) {
         clientProvider = new ThreadLocalClientProvider(cConf, discoveryServiceClient);
       } else {

--- a/tephra-core/src/test/java/co/cask/tephra/distributed/ElasticPooledClientProviderTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/distributed/ElasticPooledClientProviderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.tephra.distributed;
+
+import co.cask.tephra.TxConstants;
+import co.cask.tephra.runtime.ConfigModule;
+import co.cask.tephra.runtime.DiscoveryModules;
+import co.cask.tephra.runtime.TransactionClientModule;
+import co.cask.tephra.runtime.TransactionModules;
+import co.cask.tephra.runtime.ZKModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class ElasticPooledClientProviderTest extends ClientProviderTestBase {
+
+  public static final int MAX_CLIENT_COUNT = 3;
+
+  @Override
+  protected void configureConf(Configuration conf) {
+    conf.setInt(TxConstants.Service.CFG_DATA_TX_CLIENT_COUNT, MAX_CLIENT_COUNT);
+  }
+
+  // tests ClientConnectionPool maximum number of clients
+  protected void startClientAndTestPool(Configuration conf) throws Exception {
+    Injector injector = Guice.createInjector(
+      new ConfigModule(conf),
+      new ZKModule(),
+      new DiscoveryModules().getDistributedModules(),
+      new TransactionModules().getDistributedModules(),
+      new TransactionClientModule()
+    );
+
+    ZKClientService zkClient = injector.getInstance(ZKClientService.class);
+    zkClient.startAndWait();
+
+    final ElasticPooledClientProvider clientProvider = new ElasticPooledClientProvider(conf,
+      injector.getInstance(DiscoveryServiceClient.class));
+
+    //Now race to get MAX_CLIENT_COUNT+1 clients, exhausting the pool and requesting 1 more.
+    List<Future<Integer>> clientIds = new ArrayList<Future<Integer>>();
+    ExecutorService executor = Executors.newFixedThreadPool(MAX_CLIENT_COUNT + 1);
+    for (int i = 0; i < MAX_CLIENT_COUNT + 1; i++) {
+      clientIds.add(executor.submit(new RetrieveClient(clientProvider)));
+    }
+
+    Set<Integer> ids = new HashSet<Integer>();
+    for (Future<Integer> id : clientIds) {
+      ids.add(id.get());
+    }
+    executor.shutdown();
+    Assert.assertEquals(MAX_CLIENT_COUNT, ids.size());
+  }
+
+
+  protected static class RetrieveClient implements Callable<Integer> {
+    private final ThriftClientProvider pool;
+
+    public RetrieveClient(ThriftClientProvider pool) {
+      this.pool = pool;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+      TransactionServiceThriftClient client = pool.getClient();
+      int id = System.identityHashCode(client);
+      try {
+        //"use" the client
+        Thread.sleep(100);
+      } finally {
+        pool.returnClient(client);
+      }
+      return id;
+    }
+  }
+}

--- a/tephra-core/src/test/java/co/cask/tephra/distributed/TimedObjectPoolTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/distributed/TimedObjectPoolTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.distributed;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests {@link TimedObjectPool}.
+ */
+public class TimedObjectPoolTest {
+
+  private static final class ElementWithId {
+    private final int id;
+
+    public ElementWithId(int id) {
+      this.id = id;
+    }
+
+    public int getId() {
+      return id;
+    }
+  }
+
+  private static final class ElementWithIdPool extends TimedObjectPool<ElementWithId, Exception> {
+
+    private int counter;
+
+    public ElementWithIdPool(long timeoutMillis) {
+      super(timeoutMillis);
+      this.counter = 0;
+    }
+
+    @Override
+    protected ElementWithId create() throws Exception {
+      return new ElementWithId(counter++);
+    }
+  }
+
+  @Test
+  public void test() throws Exception {
+    final int timeoutInMillis = 50;
+    ElementWithIdPool pool = new ElementWithIdPool(timeoutInMillis);
+    ElementWithId obtain0 = pool.obtain();
+    Assert.assertEquals(0, obtain0.getId());
+    ElementWithId obtain1 = pool.obtain();
+    Assert.assertEquals(1, obtain1.getId());
+    ElementWithId obtain2 = pool.obtain();
+    Assert.assertEquals(2, obtain2.getId());
+
+    // release them in order: 0, 1, 2 and so the following calls to obtain() should return them in order: 2, 1, 0 (FILO)
+    pool.release(obtain0);
+    pool.release(obtain1);
+    pool.release(obtain2);
+
+    obtain0 = pool.obtain();
+    obtain1 = pool.obtain();
+    obtain2 = pool.obtain();
+
+    Assert.assertEquals(2, obtain0.getId());
+    Assert.assertEquals(1, obtain1.getId());
+    Assert.assertEquals(0, obtain2.getId());
+
+    // release id='2' and wait twice the timeout, to ensure it qualifies for cleanup.
+    pool.release(obtain0);
+    TimeUnit.MILLISECONDS.sleep(timeoutInMillis * 2);
+
+    pool.release(obtain1);
+    pool.release(obtain2);
+
+    // id '2' was destroyed due to the timeout, so we should get: 0, 1, 3
+    obtain0 = pool.obtain();
+    obtain1 = pool.obtain();
+    obtain2 = pool.obtain();
+
+    Assert.assertEquals(0, obtain0.getId());
+    Assert.assertEquals(1, obtain1.getId());
+    Assert.assertEquals(3, obtain2.getId());
+  }
+}

--- a/tephra-core/src/test/java/co/cask/tephra/distributed/TimedPooledClientProviderTest.java
+++ b/tephra-core/src/test/java/co/cask/tephra/distributed/TimedPooledClientProviderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.tephra.distributed;
+
+import co.cask.tephra.TxConstants;
+import co.cask.tephra.runtime.ConfigModule;
+import co.cask.tephra.runtime.DiscoveryModules;
+import co.cask.tephra.runtime.TransactionClientModule;
+import co.cask.tephra.runtime.TransactionModules;
+import co.cask.tephra.runtime.ZKModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class TimedPooledClientProviderTest extends ClientProviderTestBase {
+
+  public static final long POOL_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
+
+  @Override
+  protected void configureConf(Configuration conf) {
+    conf.setLong(TxConstants.Service.CFG_DATA_TX_CLIENT_POOL_TIMEOUT, POOL_TIMEOUT);
+  }
+
+  // tests ClientConnectionPool maximum number of clients
+  protected void startClientAndTestPool(Configuration conf) throws Exception {
+    Injector injector = Guice.createInjector(
+      new ConfigModule(conf),
+      new ZKModule(),
+      new DiscoveryModules().getDistributedModules(),
+      new TransactionModules().getDistributedModules(),
+      new TransactionClientModule()
+    );
+
+    ZKClientService zkClient = injector.getInstance(ZKClientService.class);
+    zkClient.startAndWait();
+
+    final TimedPooledClientProvider clientProvider = new TimedPooledClientProvider(conf,
+      injector.getInstance(DiscoveryServiceClient.class));
+
+
+    int numThreads = 5;
+
+    List<Future<TransactionServiceThriftClient>> clientFutures = new ArrayList<>();
+    List<TransactionServiceThriftClient> clients = new ArrayList<>();
+
+    ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+    for (int i = 0; i < numThreads; i++) {
+      clientFutures.add(executor.submit(new RetrieveClient(clientProvider)));
+    }
+
+    for (Future<TransactionServiceThriftClient> clientFuture : clientFutures) {
+      clients.add(clientFuture.get());
+    }
+
+    // introduce a delay, so that the clients qualify for cleanup
+    TimeUnit.MILLISECONDS.sleep(POOL_TIMEOUT);
+
+    // trigger a cleanup, which happens in TimedObjectPool#obtain()
+    clientProvider.getClient();
+
+    int numOpenClients = 0;
+    // the first four should have been destroyed (and therefore closed)
+    for (int i = 0; i < numThreads; i++) {
+      if (clients.get(i).transport.isOpen()) {
+        numOpenClients++;
+      }
+    }
+    // only one client is still open (not destroyed/cleaned up), because it was returned
+    // in the clientProvider.getClient() call, which was used to trigger the cleanup
+    Assert.assertEquals(1, numOpenClients);
+
+    executor.shutdown();
+  }
+
+
+  protected static class RetrieveClient implements Callable<TransactionServiceThriftClient> {
+    private final ThriftClientProvider pool;
+
+    public RetrieveClient(ThriftClientProvider pool) {
+      this.pool = pool;
+    }
+
+    @Override
+    public TransactionServiceThriftClient call() throws Exception {
+      TransactionServiceThriftClient client = pool.getClient();
+      try {
+        //"use" the client
+        Thread.sleep(100);
+      } finally {
+        pool.returnClient(client);
+      }
+      return client;
+    }
+  }
+}


### PR DESCRIPTION
Implement a TimedObjectPool, which is an object pool that times out (destroys and discards the objects) after a certain amount of time of non-use.

https://issues.cask.co/browse/CDAP-4067
https://issues.cask.co/browse/TEPHRA-142

Testing on cluster currently in progress.