### PR TITLE
TEPHRA-142 improve elastic pool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,11 +263,18 @@ properties can be added to the ``hbase-site.xml`` file on the client's ``CLASSPA
 +==========================================+===========+===============================================+
 | ``data.tx.client.timeout``               | 30000     | Client socket timeout (milliseconds)          |
 +------------------------------------------+-----------+-----------------------------------------------+
-| ``data.tx.client.provider``              | pool      | Client provider strategy: "pool" uses a pool  |
-|                                          |           | of clients; "thread-local" a client per       |
-|                                          |           | thread                                        |
+| ``data.tx.client.provider``              | pool      | Client provider strategy:                     |
+|                                          |           |                                               |
+|                                          |           | - "pool" uses a pool of clients               |
+|                                          |           | - "thread-local" a client per thread          |
+|                                          |           |                                               |
+|                                          |           | Note that "thread-local" provider can have a  |
+|                                          |           | resource leak if threads are recycled         |
 +------------------------------------------+-----------+-----------------------------------------------+
-| ``data.tx.client.count``                 | 5         | Max number of clients for "pool" provider     |
+| ``data.tx.client.count``                 | 50        | Max number of clients for "pool" provider     |
++------------------------------------------+-----------+-----------------------------------------------+
+| ``data.tx.client.obtain.timeout``        | 3000      | Timeout (milliseconds) to wait when obtaining |
+|                                          |           | clients from the "pool" provider              |
 +------------------------------------------+-----------+-----------------------------------------------+
 | ``data.tx.client.retry.strategy``        | backoff   | Client retry strategy: "backoff" for back off |
 |                                          |           | between attempts; "n-times" for fixed number  |

--- a/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/co/cask/tephra/TxConstants.java
@@ -218,6 +218,10 @@ public class TxConstants {
     public static final String CFG_DATA_TX_CLIENT_COUNT
       = "data.tx.client.count";
 
+    /** timeout (in milliseconds) for obtaining client from client provider "pool". */
+    public static final String CFG_DATA_TX_CLIENT_OBTAIN_TIMEOUT_MS
+      = "data.tx.client.obtain.timeout";
+
     /** to specify the retry strategy for a failed thrift call. */
     public static final String CFG_DATA_TX_CLIENT_RETRY_STRATEGY
       = "data.tx.client.retry.strategy";
@@ -227,7 +231,7 @@ public class TxConstants {
       = "data.tx.client.retry.attempts";
 
     /** to specify the initial sleep time for retry strategy backoff. */
-    public static final String CFG_DATA_TX_CLIENT_BACKOFF_INIITIAL
+    public static final String CFG_DATA_TX_CLIENT_BACKOFF_INITIAL
       = "data.tx.client.retry.backoff.initial";
 
     /** to specify the backoff factor for retry strategy backoff. */
@@ -239,12 +243,16 @@ public class TxConstants {
       = "data.tx.client.retry.backoff.limit";
 
     /** the default tx client socket timeout in milli seconds. */
-    public static final int DEFAULT_DATA_TX_CLIENT_TIMEOUT
+    public static final int DEFAULT_DATA_TX_CLIENT_TIMEOUT_MS
       = 30 * 1000;
 
-    /** default number of pooled tx clients. */
+    /** default number of tx clients for client provider "pool". */
     public static final int DEFAULT_DATA_TX_CLIENT_COUNT
-      = 5;
+      = 50;
+
+    /** default timeout (in milliseconds) for obtaining client from client provider "pool". */
+    public static final long DEFAULT_DATA_TX_CLIENT_OBTAIN_TIMEOUT_MS
+      = TimeUnit.SECONDS.toMillis(3);
 
     /** default tx client provider strategy. */
     public static final String DEFAULT_DATA_TX_CLIENT_PROVIDER
@@ -259,7 +267,7 @@ public class TxConstants {
       = 2;
 
     /** default initial sleep is 100ms. */
-    public static final int DEFAULT_DATA_TX_CLIENT_BACKOFF_INIITIAL
+    public static final int DEFAULT_DATA_TX_CLIENT_BACKOFF_INITIAL
       = 100;
 
     /** default backoff factor is 4. */

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/AbstractClientProvider.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/AbstractClientProvider.java
@@ -111,7 +111,7 @@ public abstract class AbstractClientProvider implements ThriftClientProvider {
     // now we have an address and port, try to connect a client
     if (timeout < 0) {
       timeout = configuration.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_TIMEOUT,
-          TxConstants.Service.DEFAULT_DATA_TX_CLIENT_TIMEOUT);
+          TxConstants.Service.DEFAULT_DATA_TX_CLIENT_TIMEOUT_MS);
     }
     LOG.info("Attempting to connect to tx service at " +
                address + ":" + port + " with timeout " + timeout + " ms.");

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/CloseableThriftClient.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/CloseableThriftClient.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tephra.distributed;
+
+/**
+ * An {@link AutoCloseable} to automatically return the thrift client to the ThriftClientProvider.
+ */
+public class CloseableThriftClient implements AutoCloseable {
+
+  private final ThriftClientProvider provider;
+  private final TransactionServiceThriftClient thriftClient;
+
+  public CloseableThriftClient(ThriftClientProvider provider, TransactionServiceThriftClient thriftClient) {
+    this.provider = provider;
+    this.thriftClient = thriftClient;
+  }
+
+  public TransactionServiceThriftClient getThriftClient() {
+    return thriftClient;
+  }
+
+  @Override
+  public void close() {
+    // in any case, the client must be returned to the pool. The pool is
+    // responsible for discarding the client if it is in a bad state.
+    provider.returnClient(thriftClient);
+  }
+}

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/ElasticPool.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/ElasticPool.java
@@ -19,16 +19,18 @@ package co.cask.tephra.distributed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
- * An Elastic Pool is an object pool that can dynamically shrink and grow.
+ * An Elastic Pool is an object pool that can dynamically grow.
  * Normally, an element is obtained by a client and then returned to the pool
- * after use. However, if the element gets into a bad state, the client can
- * also discard the element. This will cause the element to be removed from
- * the pool, and for a subsequent request, a new element can be created
- * on the fly to replace the discarded one.
+ * after use. However, if the element gets into a bad state, the element can
+ * be discarded, based upon the recycle() method returning false. This will
+ * cause the element to be removed from the pool, and for a subsequent request,
+ * a new element can be created on the fly to replace the discarded one.
  *
  * The pool starts with zero (active) elements. Every time a client attempts
  * to obtain an element, an element from the pool is returned if available.
@@ -36,13 +38,11 @@ import java.util.concurrent.BlockingQueue;
  * a new element is created (using abstract method create(), this must be
  * overridden by all implementations), and the number of active elements is
  * increased by one. If the limit is reached, then obtain() blocks until
- * either an element is returned to the pool, or an element is discarded,
- * allowing for the creation of a new element.
+ * either an element is returned to the pool or, if the obtain method with timeout
+ * parameters is used, a timeout occurs.
  *
- * Every time an element is discarded, it is "destroyed" in order to properly
- * release all it resources before discarding. Every time an element is
- * returned to the pool, it is "recycled" to restore its fresh state for the
- * next use.
+ * Every time an element is returned to the pool, it is "recycled" to restore its
+ * fresh state for the next use or destroyed, depending on its state.
  *
  * @param <T> the type of the elements
  * @param <E> the type of exception thrown by create()
@@ -61,40 +61,45 @@ public abstract class ElasticPool<T, E extends Exception> {
   protected abstract T create() throws E;
 
   /**
-   * A method to destroy an element. This gets called every time an element
-   * is discarded, to properly release all resources that the element might
-   * hold.
-   *
-   * @param element the element to destroy
-   */
-  protected void destroy(T element) {
-    // by default do nothing
-  }
-
-  /**
    * A method to recycle an existing element when it is returned to the pool.
    * This methods ensures that the element is in a fresh state before it can
-   * be reused by the next agent.
+   * be reused by the next agent. If the element is not to be returned to the pool,
+   * calling code is responsible for destroying it and returning false.
    *
    * @param element the element to recycle
+   * @return true to reuse element, false to remove it from the pool
    */
-  protected void recycle(T element) {
-    // by default do nothing
+  protected boolean recycle(T element) {
+    // by default, simply return true
+    return true;
   }
 
   // holds all currently available elements
-  private BlockingQueue<T> elements;
+  private final ConcurrentLinkedQueue<T> elements;
 
-  // number of current active elements (including ones that are in use)
-  volatile int size = 0;
-
-  // the limit for the number of active elements
-  int limit;
+  // we keep track of elements via the permits of a semaphore, because there can
+  // be elements in a queue, but also elements that are "loaned out" count towards
+  // the pool's size limit
+  private final Semaphore semaphore;
 
   public ElasticPool(int sizeLimit) {
-    elements = new ArrayBlockingQueue<>(sizeLimit);
-    limit = sizeLimit;
-    size = 0;
+    elements = new ConcurrentLinkedQueue<>();
+    semaphore = new Semaphore(sizeLimit, true);
+  }
+
+  /**
+   * Get a element from the pool. If there is an available element in
+   * the pool, it will be returned. Otherwise, if the number of active
+   * elements does not exceed the limit, a new element is created with
+   * create() and returned. Otherwise, blocks until an element is either
+   * released and returned to the pool, or an element is discarded,
+   * allowing for the creation of a new element.
+   *
+   * @return an element
+   */
+  public T obtain() throws E, TimeoutException, InterruptedException {
+    semaphore.acquire();
+    return getOrCreate();
   }
 
   /**
@@ -102,27 +107,38 @@ public abstract class ElasticPool<T, E extends Exception> {
    * the pool, it will be returned. Otherwise, if the number of active
    * elements does ot exceed the limit, a new element is created with
    * create() and returned. Otherwise, blocks until an element is either
-   * released and returned to the pool, or an element is discarded,
-   * allowing for the creation of a new element.
+   * released and returned to the pool, an element is discarded,
+   * allowing for the creation of a new element, or a timeout occurs.
    *
+   * @param timeout the timeout for trying to obtain an element
+   * @param unit the timeout unit for trying to obtain an element
    * @return an element
+   * @throws TimeoutException if a client is not able to be obtained within the given timeout
    */
-  public T obtain() throws E {
-    T element = getOrCreate();
-    while (true) {
-      if (element != null) {
-        return element;
+  public T obtain(long timeout, TimeUnit unit) throws E, TimeoutException, InterruptedException {
+    if (!semaphore.tryAcquire(1, timeout, unit)) {
+      throw new TimeoutException(String.format("Failed to obtain client within %d %s.",
+                                               timeout, unit));
+    }
+    return getOrCreate();
+  }
+
+  // gets an element from the queue, or creates one if there is none available in the queue.
+  // the semaphore must be acquired before calling this method. The semaphore will be released from within
+  // this method if it throws any exception
+  private T getOrCreate() throws E {
+    try {
+      T client = elements.poll();
+      // a client was available, all good. otherwise, create one
+      if (client != null) {
+        return client;
       }
-      synchronized (this) {
-        try {
-          this.wait();
-        } catch (InterruptedException e) {
-          LOG.warn("Wait interrupted. Don't know what to do. Ignoring.");
-          continue;
-        }
-        // got notified - try to get element
-        element = getOrCreate();
-      }
+      return create();
+    } catch (Exception e) {
+      // if an exception is thrown after acquiring the semaphore, release the
+      // semaphore before propagating the exception
+      semaphore.release();
+      throw e;
     }
   }
 
@@ -134,52 +150,12 @@ public abstract class ElasticPool<T, E extends Exception> {
    * @param element the element to be returned
    */
   public void release(T element) {
-    synchronized (this) {
-      this.recycle(element);
-      this.elements.add(element);
-      this.notify();
-    }
-  }
-
-  /**
-   * Discard an element from the pool. The element must have been obtained
-   * from this pool. The destroy() method will be called. This decreases the
-   * number of active elements, allowing for subsequent creation of a new one.
-   * @param element
-   */
-  public void discard(T element) {
-    synchronized (this) {
-      this.destroy(element);
-      this.size--;
-      this.notify();
-    }
-  }
-
-  /**
-   * If the pool has an available element, return it. Otherwise,
-   * if the active element limit is not reached, create a new element and
-   * return it. Otherwise return null.
-   * @return An elememt or null if an element is neither available nor can
-   * one be created.
-   */
-  private T getOrCreate() throws E {
-    T client = elements.poll();
-    if (client != null) {
-      // a client was available, all good
-      return client;
-    }
-    // no client available but we have not reached the max number of clients:
-    // create a new client but synchronize to make sure to avoid race with
-    // other threads.
-    synchronized (this) {
-      // verify that nobody has created a client in the meantime
-      if (size >= limit) {
-        // max clients was reached since we first checked -> block and wait
-        return null;
+    try {
+      if (recycle(element)) {
+        elements.add(element);
       }
-      client = this.create();
-      this.size++;
-      return client;
+    } finally {
+      semaphore.release();
     }
   }
 }

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/RetryWithBackoff.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/RetryWithBackoff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -81,13 +81,13 @@ public class RetryWithBackoff extends RetryStrategy {
     int maxSleep; // max sleep time. stop retrying when we exceed this
 
     public Provider() {
-      initialSleep = TxConstants.Service.DEFAULT_DATA_TX_CLIENT_BACKOFF_INIITIAL;
+      initialSleep = TxConstants.Service.DEFAULT_DATA_TX_CLIENT_BACKOFF_INITIAL;
       backoffFactor = TxConstants.Service.DEFAULT_DATA_TX_CLIENT_BACKOFF_FACTOR;
       maxSleep = TxConstants.Service.DEFAULT_DATA_TX_CLIENT_BACKOFF_LIMIT;
     }
 
     public void configure(Configuration config) {
-      initialSleep = config.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_BACKOFF_INIITIAL, initialSleep);
+      initialSleep = config.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_BACKOFF_INITIAL, initialSleep);
       backoffFactor = config.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_BACKOFF_FACTOR, backoffFactor);
       maxSleep = config.getInt(TxConstants.Service.CFG_DATA_TX_CLIENT_BACKOFF_LIMIT, maxSleep);
     }

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/SingleUseClientProvider.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/SingleUseClientProvider.java
@@ -22,6 +22,8 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.TimeoutException;
+
 /**
  * An tx client provider that creates a new connection every time.
  */
@@ -38,9 +40,9 @@ public class SingleUseClientProvider extends AbstractClientProvider {
   final int timeout;
 
   @Override
-  public TransactionServiceThriftClient getClient() throws TException {
+  public CloseableThriftClient getCloseableClient() throws TException, TimeoutException, InterruptedException {
     try {
-      return this.newClient(timeout);
+      return new CloseableThriftClient(this, newClient(timeout));
     } catch (TException e) {
       LOG.error("Unable to create new tx client: " + e.getMessage());
       throw e;
@@ -49,11 +51,6 @@ public class SingleUseClientProvider extends AbstractClientProvider {
 
   @Override
   public void returnClient(TransactionServiceThriftClient client) {
-    discardClient(client);
-  }
-
-  @Override
-  public void discardClient(TransactionServiceThriftClient client) {
     client.close();
   }
 

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/ThriftClientProvider.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/ThriftClientProvider.java
@@ -18,6 +18,8 @@ package co.cask.tephra.distributed;
 
 import org.apache.thrift.TException;
 
+import java.util.concurrent.TimeoutException;
+
 /**
  * This interface is used to provide thrift tx service clients:
  * there is only one (singleton)
@@ -43,25 +45,21 @@ public interface ThriftClientProvider {
   void initialize() throws TException;
 
   /**
-   * Retrieve an tx client for exclusive use by the current thread. The
-   * tx must be returned to the provider after use.
+   * Retrieve an AutoCloseable wrapper around  tx client for exclusive use by the
+   * current thread. The client must be closed (returned) to the provider after use.
    * @return an tx client, connected and fully functional
    */
-  TransactionServiceThriftClient getClient() throws TException;
+  CloseableThriftClient getCloseableClient() throws TException,
+    TimeoutException, InterruptedException;
 
   /**
-   * Release an tx client back to the provider's pool.
-   * @param client The client to release
-   */
-  void returnClient(TransactionServiceThriftClient client);
-
-  /**
-   * Discard an tx client from the provider's pool. This is called
-   * after a client becomes disfunctional, for instance, due to a socket
+   * Release an tx client back to the provider's pool, if the client is valid.
+   * If the client becomes disfunctional, for instance, due to a socket
    * exception. The provider must make sure to close the client, and it
    * must remove the client from its arsenal and be prepared to create
    * a new client subsequently.
-   * @param client The client to discard
+   *
+   * @param client The client to return
    */
-  void discardClient(TransactionServiceThriftClient client);
+  void returnClient(TransactionServiceThriftClient client);
 }

--- a/tephra-core/src/main/java/co/cask/tephra/distributed/TransactionServiceThriftClient.java
+++ b/tephra-core/src/main/java/co/cask/tephra/distributed/TransactionServiceThriftClient.java
@@ -16,7 +16,13 @@
 
 package co.cask.tephra.distributed;
 
+import co.cask.tephra.InvalidTruncateTimeException;
 import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionCouldNotTakeSnapshotException;
+import co.cask.tephra.TransactionNotInProgressException;
+import co.cask.tephra.distributed.thrift.TInvalidTruncateTimeException;
+import co.cask.tephra.distributed.thrift.TTransactionCouldNotTakeSnapshotException;
+import co.cask.tephra.distributed.thrift.TTransactionNotInProgressException;
 import co.cask.tephra.distributed.thrift.TTransactionServer;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
@@ -31,6 +37,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class is a wrapper around the thrift tx service client, it takes
@@ -57,9 +64,14 @@ public class TransactionServiceThriftClient {
   TTransactionServer.Client client;
 
   /**
+   * Whether this client is valid for use.
+   */
+  private final AtomicBoolean isValid = new AtomicBoolean(true);
+
+  /**
    * Constructor from an existing, connected thrift transport.
    *
-   * @param transport the thrift transport layer. It must already be comnnected
+   * @param transport the thrift transport layer. It must already be connected
    */
   public TransactionServiceThriftClient(TTransport transport) {
     this.transport = transport;
@@ -79,67 +91,152 @@ public class TransactionServiceThriftClient {
   }
 
   public Transaction startLong() throws TException {
-    return TransactionConverterUtils.unwrap(client.startLong());
+    try {
+      return TransactionConverterUtils.unwrap(client.startLong());
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
   }
 
   public Transaction startShort() throws TException {
+    try {
       return TransactionConverterUtils.unwrap(client.startShort());
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
   }
 
   public Transaction startShort(int timeout) throws TException {
+    try {
       return TransactionConverterUtils.unwrap(client.startShortTimeout(timeout));
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
   }
 
-  public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TException {
-
+  public boolean canCommit(Transaction tx, Collection<byte[]> changeIds)
+    throws TException, TransactionNotInProgressException {
+    try {
       return client.canCommitTx(TransactionConverterUtils.wrap(tx),
                                 ImmutableSet.copyOf(Iterables.transform(changeIds, BYTES_WRAPPER))).isValue();
+    } catch (TTransactionNotInProgressException e) {
+      throw new TransactionNotInProgressException(e.getMessage());
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
   }
 
-  public boolean commit(Transaction tx) throws TException {
 
+
+  public boolean commit(Transaction tx) throws TException, TransactionNotInProgressException {
+    try {
       return client.commitTx(TransactionConverterUtils.wrap(tx)).isValue();
+    } catch (TTransactionNotInProgressException e) {
+      throw new TransactionNotInProgressException(e.getMessage());
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
   }
 
   public void abort(Transaction tx) throws TException {
+    try {
       client.abortTx(TransactionConverterUtils.wrap(tx));
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
   }
 
   public boolean invalidate(long tx) throws TException {
-    return client.invalidateTx(tx);
+    try {
+      return client.invalidateTx(tx);
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
   }
 
   public Transaction checkpoint(Transaction tx) throws TException {
-    return TransactionConverterUtils.unwrap(client.checkpoint(TransactionConverterUtils.wrap(tx)));
-  }
-
-  public InputStream getSnapshotStream() throws TException {
-    ByteBuffer buffer = client.getSnapshot();
-    if (buffer.hasArray()) {
-      return new ByteArrayInputStream(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+    try {
+      return TransactionConverterUtils.unwrap(client.checkpoint(TransactionConverterUtils.wrap(tx)));
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
     }
-
-    // The ByteBuffer is not backed by array. Read the content to a new byte array and return an InputStream of that.
-    byte[] snapshot = new byte[buffer.remaining()];
-    buffer.get(snapshot);
-    return new ByteArrayInputStream(snapshot);
   }
 
-  public String status() throws TException { return client.status(); }
+  public InputStream getSnapshotStream() throws TException, TransactionCouldNotTakeSnapshotException {
+    try {
+      ByteBuffer buffer = client.getSnapshot();
+      if (buffer.hasArray()) {
+        return new ByteArrayInputStream(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+      }
+
+      // The ByteBuffer is not backed by array. Read the content to a new byte array and return an InputStream of that.
+      byte[] snapshot = new byte[buffer.remaining()];
+      buffer.get(snapshot);
+      return new ByteArrayInputStream(snapshot);
+    } catch (TTransactionCouldNotTakeSnapshotException e) {
+      throw new TransactionCouldNotTakeSnapshotException(e.getMessage());
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
+  }
+
+  public String status() throws TException {
+    try {
+      return client.status();
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
+  }
 
   public void resetState() throws TException {
-    client.resetState();
+    try {
+        client.resetState();
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
   }
 
   public boolean truncateInvalidTx(Set<Long> invalidTxIds) throws TException {
-    return client.truncateInvalidTx(invalidTxIds).isValue();
+    try {
+      return client.truncateInvalidTx(invalidTxIds).isValue();
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
   }
   
-  public boolean truncateInvalidTxBefore(long time) throws TException {
-    return client.truncateInvalidTxBefore(time).isValue();
+  public boolean truncateInvalidTxBefore(long time) throws TException, InvalidTruncateTimeException {
+    try {
+      return client.truncateInvalidTxBefore(time).isValue();
+    } catch (TInvalidTruncateTimeException e) {
+      throw new InvalidTruncateTimeException(e.getMessage());
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
   }
   
   public int getInvalidSize() throws TException {
-    return client.invalidTxSize();
+    try {
+      return client.invalidTxSize();
+    } catch (TException e) {
+      isValid.set(false);
+      throw e;
+    }
+  }
+
+  public boolean isValid() {
+    return isValid.get();
   }
 }


### PR DESCRIPTION
Simplify ElasticPool implementation.
Also introduced a timeout (default of 3 seconds), so the `obtain()` method call isn't indefinite.

https://issues.cask.co/browse/CDAP-4067
https://issues.cask.co/browse/TEPHRA-142